### PR TITLE
Fix invalid default values in MyelomaPlasmaCellDisorder schema (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ Download [the latest JAR][1] or grab via Maven:
 <dependency>
     <groupId>com.imsweb</groupId>
     <artifactId>staging-algorithm-cs</artifactId>
-    <version>02.05.50</version>
+    <version>02.05.50.1</version>
 </dependency>
 ```
 
 or via Gradle:
 
 ```groovy
-compile 'com.imsweb.com:staging-algorithm-cs:02.05.50'
+compile 'com.imsweb.com:staging-algorithm-cs:02.05.50.1'
 ```
 
 ## Usage

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.imsweb'
-version = '02.05.50'
+version = '02.05.50.1'
 description = 'Collaborative Stage algorithm for the java-staging-client'
 
 // UTF-8 for all compilation tasks

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/adnexa_uterine_other.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/adnexa_uterine_other.json
@@ -482,35 +482,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bcn",
@@ -605,32 +597,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -728,32 +712,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -857,8 +833,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -878,11 +853,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -897,11 +870,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -998,47 +969,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1048,80 +1005,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf2_kna", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "schema_selection_adnexa_uterine_other", "cs_input_version_original", "mets_hpa", "ssf22_snq", "lvi", "ssf14_sni", "mets_eval_ina", "ajcc_tdescriptor_cleanup", "ssf4_mna", "extension_eval_cna", "ajcc6_stage_qna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "grade", "summary_stage_rpa", "nodes_eval_ena", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf1_jna", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ssf3_lna", "ss_codes", "ssf6_ona", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf10_sne", "ssf18_snm", "nodes_dcc", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "cs_year_validation", "ssf24_sns", "extension_bcn", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/adrenal_gland.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/adrenal_gland.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bdp",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "site", "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_uba",
@@ -895,8 +869,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -916,11 +889,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -935,11 +906,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1036,47 +1005,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1086,80 +1041,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf25_snt", "nodes_ddk", "ajcc7_inclusions_tqc", "ssf2_kak", "size_aak", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "cs_input_version_original", "ssf22_snq", "lvi", "ssf14_sni", "ssf3_laf", "ajcc_tdescriptor_cleanup", "ssf4_mna", "schema_selection_adrenal_gland", "ajcc6_stage_qna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "mets_eval_iac", "grade", "summary_stage_rpa", "ajcc7_m_codes", "extension_eval_caj", "mets_hbv", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "extension_size_xde", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "nodes_eval_eah", "ssf7_snb", "ssf11_snf", "ss_codes", "ssf6_ona", "ssf1_jba", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "extension_bdp", "ssf10_sne", "ssf18_snm", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "cs_year_validation", "ssf24_sns", "ajcc7_stage_uba", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/ampulla_vater.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/ampulla_vater.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bde",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_uaa",
@@ -895,8 +869,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -916,11 +889,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -939,11 +910,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpp",
@@ -985,11 +954,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1000,8 +967,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1090,47 +1056,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1140,80 +1092,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ajcc6_exclusions_ppe", "ssf25_snt", "ssf1_jpe", "ssf15_snj", "ajcc7_t_codes", "ssf3_lpc", "ssf23_snr", "histology", "cs_input_version_original", "ssf22_snq", "lvi", "ssf14_sni", "ajcc7_stage_uaa", "ajcc_tdescriptor_cleanup", "ssf4_mna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "ajcc7_inclusions_tpe", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpc", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "extension_bde", "ss_codes", "ssf6_ona", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "mets_har", "behavior", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ajcc6_stage_qpp", "schema_selection_ampulla_vater", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "nodes_dbo", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/anus.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/anus.json
@@ -481,35 +481,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_baa",
@@ -604,32 +596,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -727,32 +711,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -854,11 +830,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_uab",
@@ -897,8 +871,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -918,11 +891,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -941,11 +912,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qbj",
@@ -987,11 +956,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1002,8 +969,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1092,47 +1058,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1142,80 +1094,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf2_kna", "ajcc6_exclusions_ppd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "ajcc7_stage_uab", "cs_input_version_original", "mets_hpc", "ssf22_snq", "lvi", "ssf14_sni", "extension_size_xaa", "ajcc_tdescriptor_cleanup", "nodes_dab", "ssf4_mna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "extension_baa", "ajcc7_inclusions_tpe", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ssf3_lna", "ss_codes", "ajcc6_stage_qbj", "ssf6_ona", "nodes_exam_gpa", "ajcc6_n_codes", "size_apf", "behavior", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "schema_selection_anus", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "ssf1_jce", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/appendix.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/appendix.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bfg",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "grade_category_calculation_xei",
@@ -898,8 +872,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -919,11 +892,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -942,11 +913,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpf",
@@ -988,11 +957,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1003,8 +970,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1093,47 +1059,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1143,80 +1095,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ajcc6_exclusions_ppd", "ssf2_kaq", "ajcc7_stage_uar", "ssf25_snt", "mets_hcf", "ssf7_spf", "ssf1_jpf", "ssf15_snj", "size_aam", "ajcc7_t_codes", "extension_bfg", "ssf23_snr", "ssf3_lpe", "histology", "lymph_nodes_pathologic_evaluation_ajcc7_table_also_used_when_cslymph_nodes_evalis_not_coded_xeg", "determine_correct_table_for_ajcc6_n_ns1", "cs_input_version_original", "ssf22_snq", "ssf10_spi", "lvi", "extension_mets_ajcc6_xeh", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "lymph_nodes_clinical_evaluation_ajcc6_xbk", "ajcc7_inclusions_tpc", "grade", "summary_stage_rpa", "ajcc7_m_codes", "lymph_nodes_pathologic_evaluation_ajcc6_table_also_used_when_cslymph_nodes_eval_is_not_coded_xpr", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "determine_correct_table_for_ajcc7_n_ns2", "ssf12_sbu", "nodes_dfc", "ajcc6_t_codes", "nodes_pos_fpb", "ajcc_mdescriptor_cleanup", "ss_codes", "ssf6_ona", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "mets_eval_ipb", "ssf18_snm", "ajcc6_stage_qpf", "extension_eval_cpa", "ajcc7_n_codes", "ssf4_mpb", "lymph_nodes_clinical_eval_priorto_v0205_ajcc7_xee", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "schema_selection_appendix", "ssf11_sbt", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "grade_category_calculation_xei", "cs_year_validation", "ssf24_sns", "lymph_nodes_clinical_eval_v0205_ajcc7_xcd", "ssf8_snc" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/bile_ducts_distal.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/bile_ducts_distal.json
@@ -480,35 +480,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bfs",
@@ -603,32 +595,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -726,32 +710,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -853,11 +829,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ssf25_sqi",
@@ -900,8 +874,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -921,11 +894,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -944,11 +915,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ssf25_sqi",
@@ -994,11 +963,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1009,8 +976,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1099,47 +1065,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1149,80 +1101,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf2_kna", "ajcc6_exclusions_ppd", "mets_hcq", "ssf13_sqg", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ajcc6_stage_qpv", "histology", "cs_input_version_original", "ssf12_sqf", "extension_bfs", "ssf22_snq", "lvi", "ajcc_tdescriptor_cleanup", "ssf4_mna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "ajcc7_inclusions_tpe", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf1_jna", "ajcc6_t_codes", "nodes_dfn", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "lymph_nodes_metsat_dxajcc6_xjc", "ssf7_snb", "ssf11_snf", "ssf3_lna", "ss_codes", "ssf6_ona", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf25_sqi", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "schema_selection_bile_ducts_distal", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "primary_site", "ajcc6_year_validation", "ajcc7_stage_ubm", "ssf14_sqh", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf8_snc" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/bile_ducts_intrahepat.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/bile_ducts_intrahepat.json
@@ -480,35 +480,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bfa",
@@ -603,32 +595,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -726,32 +710,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -853,11 +829,9 @@
       "inputs" : [ "site", "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_ubi",
@@ -896,8 +870,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -917,11 +890,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -940,11 +911,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qcd",
@@ -986,11 +955,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1001,8 +968,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1091,47 +1057,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1141,80 +1093,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf3_lps", "ajcc7_inclusions_tpt", "ajcc6_exclusions_ppd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "cs_input_version_original", "ssf12_sqf", "ssf1_jpw", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf4_mna", "ajcc7_year_validation", "ssf21_snp", "extension_periductal_invasion_ajcc7_xks", "ssf17_snl", "ajcc_descriptor_codes", "extension_bfa", "mets_hbz", "ssf11_sqe", "grade", "summary_stage_rpa", "ajcc7_m_codes", "schema_selection_bile_ducts_intrahepat", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "extension_size_ajcc6_xda", "lymph_nodes_metsat_dxajcc6_xgq_m", "ajcc6_t_codes", "ajcc6_stage_qcd", "lymph_nodes_metsat_dxajcc6_xgq_n", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ss_codes", "ssf10_sfj", "ssf6_ona", "nodes_exam_gpa", "ssf2_kpq", "ajcc6_n_codes", "behavior", "nodes_dew", "ssf18_snm", "mets_eval_ipa", "ajcc7_n_codes", "extension_eval_cpc", "ajcc6_stage_codes", "size_apt", "ssf5_nna", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc7_stage_ubi", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf8_snc" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/bile_ducts_perihilar.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/bile_ducts_perihilar.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bft",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ssf25_sqi",
@@ -899,8 +873,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -920,11 +893,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -943,11 +914,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ssf25_sqi",
@@ -993,11 +962,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1008,8 +975,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1098,47 +1064,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1148,80 +1100,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "extension_bft", "ssf2_kna", "ajcc6_exclusions_ppd", "mets_hcr", "ssf13_sqg", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ajcc6_stage_qpv", "schema_selection_bile_ducts_perihilar", "histology", "cs_input_version_original", "ssf12_sqf", "ssf22_snq", "lvi", "ajcc_tdescriptor_cleanup", "ssf4_mna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "ssf11_sqe", "ajcc7_inclusions_tpe", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf1_jna", "ajcc6_t_codes", "nodes_pos_fpa", "nodes_dfo", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf3_lna", "ss_codes", "ssf10_sfi", "ssf6_ona", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "lymph_nodes_metsat_dxajcc6_xfo", "ssf25_sqi", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "primary_site", "ajcc6_year_validation", "ssf14_sqh", "ajcc7_stage_ubn", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf8_snc" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/biliary_other.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/biliary_other.json
@@ -482,35 +482,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bcx",
@@ -605,32 +597,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -728,32 +712,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -857,8 +833,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -878,11 +853,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -901,11 +874,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qbk",
@@ -947,11 +918,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -962,8 +931,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1052,47 +1020,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1102,80 +1056,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf2_kna", "ajcc6_exclusions_ppd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "cs_input_version_original", "ssf22_snq", "lvi", "ssf14_sni", "mets_hbj", "ajcc_tdescriptor_cleanup", "schema_selection_biliary_other", "ssf4_mna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf1_jna", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ssf3_lna", "ajcc6_stage_qbk", "ss_codes", "ssf6_ona", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "extension_bcx", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "nodes_dcl", "ssf19_snn", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/bladder.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/bladder.json
@@ -482,35 +482,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bcb",
@@ -605,32 +597,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -728,32 +712,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -859,11 +835,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_uau",
@@ -902,8 +876,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -923,11 +896,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -946,11 +917,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qbh",
@@ -992,11 +961,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1007,8 +974,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1097,47 +1063,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1147,80 +1099,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ajcc6_exclusions_ppd", "determine_correct_table_for_ajcc6_m_ns4", "ssf25_snt", "ssf2_kao", "ssf1_jpd", "ajcc7_stage_uau", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "cs_input_version_original", "determine_correct_table_for_ajcc6_n_ns3", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf4_mna", "lymph_nodes_size_mets114055or60_ajcc6_xdv_n", "ajcc7_year_validation", "ssf21_snp", "mets_hbc", "lymph_nodes_size_mets114055or60_ajcc6_xdv_m", "ajcc7_inclusions_tpb", "ssf17_snl", "ajcc_descriptor_codes", "extension_eval_cag", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "lymph_nodes_size_mets00_ajcc6_xdo_n", "lymph_nodes_size_mets00_ajcc6_xdo_m", "ajcc6_t_codes", "lymph_nodes_size_mets99_ajcc6_xdp_m", "lymph_nodes_size_mets99_ajcc6_xdp_n", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ss_codes", "ajcc6_stage_qbh", "ssf6_ona", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf3_lai", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "schema_selection_bladder", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "nodes_dck", "ssf19_snn", "ajcc7_stage_codes", "lymph_nodes_size_mets10or50_ajcc6_xid_n", "lymph_nodes_size_mets10or50_ajcc6_xid_m", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "extension_bcb", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/bone.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/bone.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bbq",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "histologies_stage_xhq_7",
@@ -895,8 +869,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -916,11 +889,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -939,11 +910,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "histologies_stage_xhq_6",
@@ -985,11 +954,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1000,8 +967,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1090,47 +1056,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1140,80 +1092,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "extension_bbq", "ajcc7_inclusions_tpy", "ajcc6_exclusions_ppc", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "size_aau", "cs_input_version_original", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ssf2_kbl", "ajcc_descriptor_codes", "ssf4_mbd", "grade", "summary_stage_rpa", "schema_selection_bone", "ajcc7_m_codes", "ajcc7_stage_not_ewing_ube", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "histologies_stage_xhq_6", "histologies_stage_xhq_7", "nodes_dbh", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf3_lay", "ssf11_snf", "ss_codes", "ssf6_ona", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "mets_hav", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ajcc7_stage_codes", "ssf1_jbx", "ssf9_snd", "ssf13_snh", "primary_site", "ajcctnm6and7_stage_ewing_xho", "ajcc6_year_validation", "extension_size_xfu", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ajcc6_stage_not_ewing_qai", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/brain.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/brain.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bcc",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_una",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -934,11 +905,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1035,47 +1004,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1085,80 +1040,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf25_snt", "ssf3_lpm", "ajcc7_stage_una", "ssf15_snj", "ajcc7_t_codes", "ssf6_opf", "ssf23_snr", "histology", "ssf1_jpo", "ajcc7_inclusions_tqf", "cs_input_version_original", "nodes_exam_gna", "ssf22_snq", "lvi", "ssf14_sni", "mets_eval_ina", "ajcc_tdescriptor_cleanup", "extension_eval_cna", "ajcc6_stage_qna", "ajcc7_year_validation", "ssf7_sqk", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "schema_selection_brain", "ssf5_nph", "nodes_pos_fna", "grade", "summary_stage_rpa", "nodes_eval_ena", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ajcc6_t_codes", "ajcc_mdescriptor_cleanup", "ssf11_snf", "ss_codes", "size_apa", "ajcc6_n_codes", "ssf2_kpl", "behavior", "nodes_dna", "mets_haw", "ssf10_sne", "ssf18_snm", "ajcc7_n_codes", "ssf8_sql", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "extension_bcc", "ssf4_mpn", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/breast.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/breast.json
@@ -477,35 +477,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bak",
@@ -600,32 +592,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -723,32 +707,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -850,11 +826,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_uac",
@@ -893,8 +867,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -914,11 +887,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -937,11 +908,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qad",
@@ -983,11 +952,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -998,8 +965,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1088,47 +1054,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1138,80 +1090,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "lymph_nodes_clinical_evaluation_xcx", "size_aab", "ssf22_san", "ssf23_sao", "ssf5_naa", "ssf25_snt", "extension_behavior_xci", "schema_selection_breast", "lymph_nodes_positive_axillary_node_xcy", "ajcc7_t_codes", "extension_size_xar", "determine_correct_table_for_ajcc6_n_ns9", "histology", "ssf24_sap", "cs_input_version_original", "ajcc7_stage_uac", "nodes_pos_fab", "lvi", "ssf3_lac", "ajcc_tdescriptor_cleanup", "ssf11_sae", "ssf16_sah", "ssf14_sbf", "ssf20_sal", "ajcc7_year_validation", "nodes_daj", "ajcc_descriptor_codes", "ajcc7_inclusions_tpg", "ssf10_sad", "ssf15_sbg", "ajcc6_stage_qad", "ssf21_sam", "grade", "summary_stage_rpa", "ssf17_sai", "ajcc7_m_codes", "ssf1_jag", "ajcc_ndescriptor_cleanup", "extension_bak", "ssf19_sak", "ssf6_oaa", "ajcc6_t_codes", "ssf18_saj", "ajcc_mdescriptor_cleanup", "ajcc6_exclusions_pan", "ss_codes", "ssf7_saa", "nodes_exam_gpa", "ssf4_mab", "ajcc6_n_codes", "behavior", "mets_hau", "mets_eval_ipa", "ssf8_sab", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf12_saf", "ajcc7_stage_codes", "ihcmol_xcc", "primary_site", "ajcc6_year_validation", "ssf2_kac", "lymph_nodes_pathologic_evaluation_xcw", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf9_sac", "ssf13_sag" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/buccal_mucosa.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/buccal_mucosa.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bai",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upt",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -938,11 +909,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpk",
@@ -984,11 +953,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -999,8 +966,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1089,47 +1055,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1139,80 +1091,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ajcc6_exclusions_ppd", "ssf1_jpa", "ssf25_snt", "schema_selection_buccal_mucosa", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "mets_hpb", "extension_size_xag", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "nodes_dah", "ajcc7_inclusions_tpb", "ssf17_snl", "lymph_nodes_size_xpg", "ajcc_descriptor_codes", "ssf5_npa", "grade", "extension_bai", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_stage_upt", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "nodes_exam_gpa", "size_apc", "ajcc6_n_codes", "behavior", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ajcc6_stage_qpk", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/carcinoid_appendix.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/carcinoid_appendix.json
@@ -480,35 +480,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bdu",
@@ -603,32 +595,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -726,32 +710,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -853,11 +829,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_uak",
@@ -896,8 +870,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -917,11 +890,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -940,11 +911,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpf",
@@ -986,11 +955,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1001,8 +968,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1091,47 +1057,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1141,80 +1093,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ajcc6_exclusions_ppd", "ssf25_snt", "size_aal", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "determine_correct_table_for_ajcc6_n_ns8", "ajcc7_stage_uak", "histology", "cs_input_version_original", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf4_mna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "nodes_ddp", "ssf2_sbz", "grade", "summary_stage_rpa", "ajcc7_m_codes", "lymph_nodes_pathologic_evaluation_ajcc6_table_also_used_when_cslymph_nodes_eval_is_not_coded_xpr", "ssf20_sno", "mets_hbx", "ajcc_ndescriptor_cleanup", "ajcc7_inclusions_tpm", "ssf16_snk", "extension_bdu", "ssf13_sca", "lymph_nodes_clinical_evaluation_ajcc6_xpq", "ajcc6_t_codes", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ssf3_lna", "ss_codes", "ssf6_ona", "nodes_exam_gpa", "ajcc6_n_codes", "schema_selection_carcinoid_appendix", "extension_size_ajcc7_xdj", "behavior", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "ajcc6_stage_qpf", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "primary_site", "ajcc6_year_validation", "nodes_pos_fpc", "ssf1_jcd", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/cervix.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/cervix.json
@@ -474,35 +474,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bbk",
@@ -597,32 +589,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -720,32 +704,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -847,11 +823,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_ubh",
@@ -890,8 +864,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -911,11 +884,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -934,11 +905,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qaz",
@@ -980,11 +949,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -995,8 +962,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1085,47 +1051,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1135,80 +1087,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf3_lpu", "size_aac", "ajcc6_exclusions_ppd", "csextension_size_tablefor_ajcc6th_xba", "ssf25_snt", "ssf9_sdz", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "extension_bbk", "cs_input_version_original", "ssf22_snq", "lvi", "ssf8_sdy", "ssf14_sni", "ajcc6_stage_qaz", "ssf5_npm", "ajcc_tdescriptor_cleanup", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpb", "ssf17_snl", "ajcc_descriptor_codes", "ssf7_sdx", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "extension_size_ajcc7_xgi", "ssf16_snk", "nodes_dbc", "mets_han", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf11_snf", "ss_codes", "ssf6_oaw", "nodes_exam_gpa", "ssf2_kpr", "ajcc6_n_codes", "behavior", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf1_jbv", "ssf19_snn", "ajcc7_stage_codes", "ssf13_snh", "primary_site", "ajcc6_year_validation", "schema_selection_cervix", "ssf4_mps", "ajcc7_stage_ubh", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/cns_other.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/cns_other.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bcd",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_una",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -934,11 +905,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1035,47 +1004,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1085,80 +1040,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf25_snt", "ssf3_lpm", "ajcc7_stage_una", "ssf15_snj", "ajcc7_t_codes", "ssf6_opf", "ssf23_snr", "schema_selection_cns_other", "histology", "ssf1_jpo", "ajcc7_inclusions_tqf", "cs_input_version_original", "mets_hpa", "nodes_exam_gna", "ssf22_snq", "lvi", "ssf14_sni", "mets_eval_ina", "ajcc_tdescriptor_cleanup", "extension_eval_cna", "ajcc6_stage_qna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "ssf5_nph", "nodes_pos_fna", "grade", "summary_stage_rpa", "nodes_eval_ena", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ajcc6_t_codes", "ajcc_mdescriptor_cleanup", "ssf11_snf", "ss_codes", "size_apa", "ajcc6_n_codes", "ssf2_kpl", "behavior", "nodes_dna", "ssf10_sne", "ssf18_snm", "ajcc7_n_codes", "ssf8_sql", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "extension_bcd", "ssf4_mpn", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "cs_year_validation", "ssf24_sns", "ssf7_sfl", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/colon.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/colon.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bao",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upw",
@@ -895,8 +869,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -916,11 +889,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -939,11 +910,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpf",
@@ -985,11 +954,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1000,8 +967,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1090,47 +1056,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1140,80 +1092,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ajcc6_exclusions_ppd", "lymph_nodes_clinical_eval_v0205_ajcc7_xaj", "size_aad", "ssf25_snt", "ssf7_spf", "ssf1_jpf", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf3_lpe", "histology", "ssf6_opb", "schema_selection_colon", "cs_input_version_original", "ssf22_snq", "ssf10_spi", "lvi", "ssf14_sni", "lymph_nodes_pathologic_evaluation_ajcc7_table_also_used_when_cslymph_nodes_evalis_not_coded_xqi", "ajcc_tdescriptor_cleanup", "extension_bao", "ajcc7_year_validation", "ssf21_snp", "ssf5_npb", "ssf17_snl", "ssf9_sph", "determine_correct_table_for_ajcc6_n_ns10", "ajcc_descriptor_codes", "lymph_nodes_clinical_evaluation_ajcc6_xbj", "ajcc7_inclusions_tpc", "ajcc7_stage_upw", "grade", "ssf8_spg", "summary_stage_rpa", "ajcc7_m_codes", "lymph_nodes_pathologic_evaluation_ajcc6_table_also_used_when_cslymph_nodes_eval_is_not_coded_xpr", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ajcc6_t_codes", "nodes_pos_fpb", "mets_hae", "ajcc_mdescriptor_cleanup", "ssf11_snf", "ss_codes", "nodes_exam_gpa", "ssf2_kpp", "nodes_dan", "ajcc6_n_codes", "behavior", "mets_eval_ipb", "ssf18_snm", "ajcc6_stage_qpf", "extension_eval_cpa", "ajcc7_n_codes", "ssf4_mpb", "ajcc6_stage_codes", "ssf19_snn", "determine_correct_table_for_ajcc7_n_ns11", "lymph_nodes_clinical_eval_priorto_v0205_ajcc7_xqh", "ajcc7_stage_codes", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/conjunctiva.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/conjunctiva.json
@@ -481,35 +481,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bbj",
@@ -604,32 +596,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -727,32 +711,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -854,11 +830,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_unb",
@@ -897,8 +871,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -918,11 +891,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -941,11 +912,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qnb",
@@ -987,11 +956,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1002,8 +969,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1092,47 +1058,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1142,80 +1094,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ajcc6_exclusions_ppd", "extension_size_table_csv2_xez", "ssf25_snt", "ajcc7_stage_unb", "schema_selection_conjunctiva", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "nodes_dpa", "size_aaq", "histology", "extension_bbj", "cs_input_version_original", "mets_hpc", "ssf22_snq", "lvi", "ssf2_kay", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf4_mna", "ajcc6_stage_qnb", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpb", "ssf17_snl", "ajcc_descriptor_codes", "extension_size_table_csv1_xas", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ssf3_lna", "ss_codes", "ssf6_ona", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf1_jbk", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/corpus_adenosarcoma.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/corpus_adenosarcoma.json
@@ -480,35 +480,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bfl",
@@ -603,32 +595,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -726,32 +710,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -853,11 +829,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_ubt",
@@ -896,8 +870,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -917,11 +890,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -940,11 +911,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -986,11 +955,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1001,8 +968,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1091,47 +1057,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1141,80 +1093,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "mets_hcl", "ssf3_lpp", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf6_opg", "ajcc7_inclusions_tqh", "ssf23_snr", "histology", "cs_input_version_original", "extension_bfl", "ssf22_snq", "lvi", "ssf14_sni", "ssf5_npk", "ajcc_tdescriptor_cleanup", "extension_cytology_summary_stage_xkl", "ajcc6_stage_qna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ajcc6_t_codes", "nodes_pos_fpa", "nodes_dfh", "ajcc_mdescriptor_cleanup", "ssf11_snf", "ss_codes", "ssf7_sqn", "size_apa", "nodes_exam_gpa", "ajcc6_exclusions_pae", "ssf2_kpo", "ajcc6_n_codes", "behavior", "ssf10_sne", "ssf8_sqo", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "schema_selection_corpus_adenosarcoma", "ajcc7_stage_ubt", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ssf1_jca", "ssf4_mpq", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/corpus_carcinoma.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/corpus_carcinoma.json
@@ -480,35 +480,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bbl",
@@ -603,32 +595,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -726,32 +710,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -853,11 +829,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_ubs",
@@ -896,8 +870,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -917,11 +890,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -940,11 +911,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpw",
@@ -986,11 +955,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1001,8 +968,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1091,47 +1057,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1141,80 +1093,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf3_lpp", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf6_opg", "ssf23_snr", "ajcc6_stage_qpw", "histology", "ajcc7_inclusions_tqg", "cs_input_version_original", "ssf22_snq", "lvi", "extension_bbl", "ssf14_sni", "ssf5_npk", "determine_correct_table_for_ajcc6_t_ns6", "ajcc_tdescriptor_cleanup", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "mets_ham", "extension_cytology_ajcc6_table_csv1_xkn", "ajcc6_t_codes", "nodes_pos_fpa", "nodes_dbd", "ajcc_mdescriptor_cleanup", "schema_selection_corpus_carcinoma", "ssf11_snf", "ss_codes", "ssf7_sqn", "size_apa", "nodes_exam_gpa", "ajcc6_exclusions_pae", "extension_cytology_summary_stage_xqa", "ssf2_kpo", "ajcc6_n_codes", "extension_cytology_ajcc6_table_csv2_xkm", "behavior", "ssf10_sne", "ssf8_sqo", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ajcc7_stage_ubs", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf1_jbz", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ssf4_mpq", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/corpus_sarcoma.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/corpus_sarcoma.json
@@ -480,35 +480,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bfm",
@@ -603,32 +595,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -726,32 +710,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -853,11 +829,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_ubu",
@@ -896,8 +870,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -917,11 +890,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -940,11 +911,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpw",
@@ -986,11 +955,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1001,8 +968,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1091,47 +1057,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1141,80 +1093,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "mets_hcm", "ssf3_lpp", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf6_opg", "ssf23_snr", "ajcc7_inclusions_tqi", "ajcc6_stage_qpw", "histology", "cs_input_version_original", "extension_bfm", "ssf22_snq", "lvi", "ssf14_sni", "ssf5_npk", "ajcc_tdescriptor_cleanup", "schema_selection_corpus_sarcoma", "determine_correct_table_for_ajcc6_t_ns7", "extension_size_ajcc7_xkr", "ajcc7_year_validation", "extension_cytology_summary_stage_xkp", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "nodes_dfi", "extension_cytology_ajcc6_table_csv1_xko", "ssf11_snf", "ss_codes", "ssf7_sqn", "nodes_exam_gpa", "ajcc6_exclusions_pae", "ssf2_kpo", "ajcc6_n_codes", "behavior", "ssf1_jbh", "extension_cytology_ajcc6_table_csv2_xkq", "ssf10_sne", "ssf8_sqo", "ssf18_snm", "mets_eval_ipa", "size_app", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ajcc7_stage_ubu", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ssf4_mpq", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/cystic_duct.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/cystic_duct.json
@@ -483,35 +483,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bfw",
@@ -606,32 +598,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -729,32 +713,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -856,11 +832,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ssf25_sqi",
@@ -903,8 +877,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -924,11 +897,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -947,11 +918,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ssf25_sqi",
@@ -997,11 +966,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1012,8 +979,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1102,47 +1068,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1152,80 +1104,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "extension_bfw", "ssf2_kna", "ajcc6_exclusions_ppd", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ajcc6_stage_qpv", "histology", "cs_input_version_original", "mets_hcv", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf4_mna", "ajcc7_stage_uqb", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "schema_selection_cystic_duct", "ajcc7_inclusions_tpe", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf1_jna", "ajcc6_t_codes", "lymph_nodes_metsat_dxajcc6_xjd", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ssf3_lna", "ss_codes", "ssf6_ona", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf25_sqi", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "nodes_dfr", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/digestive_other.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/digestive_other.json
@@ -482,35 +482,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bcg",
@@ -605,32 +597,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -728,32 +712,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -857,8 +833,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -878,11 +853,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -897,11 +870,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -998,47 +969,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1048,80 +1005,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf2_kna", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "cs_input_version_original", "mets_hpa", "ssf22_snq", "lvi", "ssf14_sni", "mets_eval_ina", "ajcc_tdescriptor_cleanup", "ssf4_mna", "extension_eval_cna", "ajcc6_stage_qna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "grade", "summary_stage_rpa", "nodes_eval_ena", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "schema_selection_digestive_other", "ssf1_jna", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ssf3_lna", "ss_codes", "ssf6_ona", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf10_sne", "ssf18_snm", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "extension_bcg", "ajcc6_m_codes", "nodes_dbx", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/endocrine_other.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/endocrine_other.json
@@ -481,35 +481,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bco",
@@ -604,32 +596,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -727,32 +711,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -856,8 +832,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -877,11 +852,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -896,11 +869,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -997,47 +968,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1047,80 +1004,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf2_kna", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "cs_input_version_original", "mets_hpa", "ssf22_snq", "lvi", "ssf14_sni", "mets_eval_ina", "ajcc_tdescriptor_cleanup", "ssf4_mna", "extension_eval_cna", "ajcc6_stage_qna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "grade", "summary_stage_rpa", "nodes_eval_ena", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ajcc6_t_codes", "ajcc_mdescriptor_cleanup", "ssf1_jaw", "ssf7_snb", "ssf11_snf", "ssf3_lna", "ss_codes", "nodes_exam_gpb", "ssf6_ona", "size_apa", "ajcc6_n_codes", "schema_selection_endocrine_other", "behavior", "ssf10_sne", "ssf18_snm", "nodes_dcd", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "nodes_pos_fpd", "ajcc6_m_codes", "cs_year_validation", "extension_bco", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/epiglottis_anterior.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/epiglottis_anterior.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bcw",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upt",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -938,11 +909,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpk",
@@ -984,11 +953,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -999,8 +966,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1089,47 +1055,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1139,80 +1091,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ajcc6_exclusions_ppd", "ssf1_jpa", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "nodes_dcs", "schema_selection_epiglottis_anterior", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "mets_hpb", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpb", "ssf17_snl", "lymph_nodes_size_xpg", "ajcc_descriptor_codes", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_stage_upt", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf11_snf", "ss_codes", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "extension_bcw", "ssf4_mpa", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ajcc6_stage_qpk", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/esophagus.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/esophagus.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bbb",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "histologies_stage_xhw",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -938,11 +909,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qah",
@@ -984,11 +953,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -999,8 +966,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1089,47 +1055,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1139,80 +1091,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "schema_selection_esophagus", "ssf2_kas", "ajcc6_exclusions_ppd", "ssf25_snt", "size_aag", "ssf3_lpl", "lymph_nodes_clinical_eval_v0205_ajcc7_xaw", "lymph_nodes_pathologic_evaluation_ajcc7_table_also_used_when_cslymph_nodes_eval_is_not_coded_xfr", "ssf15_snj", "ajcc7_t_codes", "extension_bbb", "ssf23_snr", "histology", "ssf1_jpn", "cs_input_version_original", "lymph_nodes_metsat_dxtable_ajcc6_xfv", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpb", "histologies_stage_xhw", "ssf5_npg", "ssf17_snl", "mets_hbg", "ajcc_descriptor_codes", "lymph_nodes_clinical_eval_priorto_v0205_ajcc7_xfq", "ajcc6_stage_qah", "ajcctnm7_stage_squamous_xhy", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ajcc6_t_codes", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ss_codes", "ssf6_ona", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "nodes_dat", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "ajcctnm7_stage_adenocarcinoma_xhz", "primary_site", "ajcc6_year_validation", "determine_correct_table_for_ajcc7_n_ns12", "nodes_pos_fpc", "ajcc6_m_codes", "nodes_eval_epa", "ssf4_mpg", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/esophagus_gejunction.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/esophagus_gejunction.json
@@ -480,35 +480,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bdr",
@@ -603,32 +595,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -726,32 +710,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -853,11 +829,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ssf25_spv",
@@ -900,8 +874,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -921,11 +894,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -944,11 +915,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ssf25_spv",
@@ -994,11 +963,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1009,8 +976,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1099,47 +1065,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1149,80 +1101,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf2_kna", "ajcc6_exclusions_ppd", "size_aah", "ssf3_lpl", "nodes_ddm", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "lymph_nodes_clinical_eval_v0205_ajcc7_xax", "cs_input_version_original", "lymph_nodes_pathologic_evaluation6th_table_also_used_when_csreg_nodes_evalis_not_coded_xpp", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "histologies_stage_xhx", "ajcc7_year_validation", "ssf21_snp", "ssf5_npg", "ssf17_snl", "lymph_nodes_clinical_evaluation0or5_ajcc6_xbg", "ajcc_descriptor_codes", "determine_correct_table_for_ajcc6_n_ns13", "ajcc7_inclusions_tpc", "lymph_nodes_clinical_eval_priorto_v0205_ajcc7_xfs", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ajcctnm7_stage_squamous_xia", "mets_hbu", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "lymph_nodes_clinical_evaluation1or9_ajcc6_xbf", "extension_bdr", "lymph_nodes_pathologic_evaluation7th_table_also_used_when_csreg_nodes_evalis_not_coded_xft", "ajcc6_t_codes", "ssf25_spv", "ajcc6_stage_qcb", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ss_codes", "ssf6_ona", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf10_sne", "ssf18_snm", "schema_selection_esophagus_gejunction", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "determine_correct_table_for_ajcc7_n_ns14", "ajcc6_year_validation", "ajcctnm7_stage_adenocarcinoma_xib", "nodes_pos_fpc", "ajcc6_m_codes", "nodes_eval_epa", "ssf4_mpg", "ssf1_jcf", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/eye_other.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/eye_other.json
@@ -482,35 +482,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bpb",
@@ -605,32 +597,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -728,32 +712,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -857,8 +833,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -878,11 +853,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -897,11 +870,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -998,47 +969,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1048,80 +1005,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf2_kna", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "cs_input_version_original", "mets_hpa", "nodes_dpb", "ssf22_snq", "lvi", "ssf14_sni", "mets_eval_ina", "ajcc_tdescriptor_cleanup", "ssf4_mna", "extension_eval_cna", "ajcc6_stage_qna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "grade", "summary_stage_rpa", "nodes_eval_ena", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf1_jna", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ssf3_lna", "ss_codes", "ssf6_ona", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf10_sne", "ssf18_snm", "ajcc7_n_codes", "ajcc6_stage_codes", "extension_bpb", "ssf5_nna", "schema_selection_eye_other", "ssf19_snn", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/fallopian_tube.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/fallopian_tube.json
@@ -480,35 +480,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bbh",
@@ -603,32 +595,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -726,32 +710,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -853,11 +829,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_ubb",
@@ -896,8 +870,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -917,11 +890,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -940,11 +911,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qac",
@@ -986,11 +955,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1001,8 +968,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1091,47 +1057,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1141,80 +1093,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ajcc6_exclusions_ppd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "ssf2_kbc", "cs_input_version_original", "extension_bbh", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpb", "ssf17_snl", "ajcc_descriptor_codes", "ssf7_sde", "schema_selection_fallopian_tube", "grade", "ajcc6_stage_qac", "summary_stage_rpa", "ssf4_mav", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "mets_hai", "ssf6_oap", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf11_snf", "ss_codes", "size_apa", "nodes_exam_gpa", "ssf3_laq", "ajcc6_n_codes", "nodes_daz", "behavior", "lymph_nodes_metsat_dxajcc6_xfm", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ssf1_jbp", "ajcc6_stage_codes", "ssf5_nas", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng", "ajcc7_stage_ubb" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/floor_mouth.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/floor_mouth.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bae",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upt",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -938,11 +909,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpk",
@@ -984,11 +953,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -999,8 +966,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1089,47 +1055,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1139,80 +1091,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ajcc6_exclusions_ppd", "ssf1_jpa", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "mets_hpb", "schema_selection_floor_mouth", "ssf22_snq", "lvi", "nodes_dpd", "ssf14_sni", "ajcc_tdescriptor_cleanup", "extension_size_xac", "ssf9_spc", "lymph_nodes_size_xpd", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpb", "ssf17_snl", "ajcc_descriptor_codes", "extension_bae", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_stage_upt", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "nodes_exam_gpa", "size_apc", "ajcc6_n_codes", "behavior", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ajcc6_stage_qpk", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/gallbladder.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/gallbladder.json
@@ -480,35 +480,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bbd",
@@ -603,32 +595,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -726,32 +710,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -853,11 +829,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_uqb",
@@ -896,8 +870,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -917,11 +890,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -940,11 +911,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qag",
@@ -986,11 +955,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1001,8 +968,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1091,47 +1057,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1141,80 +1093,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf2_kna", "ssf25_snt", "ajcc7_t_codes", "ssf23_snr", "histology", "extension_bbd", "schema_selection_gallbladder", "cs_input_version_original", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf4_mna", "ajcc7_stage_uqb", "ajcc7_year_validation", "ssf21_snp", "mets_hbe", "ssf17_snl", "ajcc_descriptor_codes", "ajcc6_stage_qag", "ajcc7_inclusions_tpe", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf1_jna", "ajcc6_t_codes", "ssf16_sdn", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ssf3_lna", "ss_codes", "ajcc6_exclusions_pac", "ssf6_ona", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf10_sne", "nodes_dav", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "lymph_nodes_metsat_dxajcc6_xhv", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ssf15_sdm", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/genital_female_other.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/genital_female_other.json
@@ -482,35 +482,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bcm",
@@ -605,32 +597,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -728,32 +712,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -857,8 +833,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -878,11 +853,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -897,11 +870,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -998,47 +969,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1048,80 +1005,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf2_kna", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "cs_input_version_original", "mets_hpa", "ssf22_snq", "lvi", "ssf14_sni", "mets_eval_ina", "ajcc_tdescriptor_cleanup", "ssf4_mna", "extension_eval_cna", "ajcc6_stage_qna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "grade", "summary_stage_rpa", "nodes_eval_ena", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf1_jna", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ssf3_lna", "ss_codes", "schema_selection_genital_female_other", "ssf6_ona", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf10_sne", "ssf18_snm", "nodes_dcb", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "cs_year_validation", "ssf24_sns", "extension_bcm", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/genital_male_other.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/genital_male_other.json
@@ -482,35 +482,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bcl",
@@ -605,32 +597,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -728,32 +712,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -857,8 +833,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -878,11 +853,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -897,11 +870,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -998,47 +969,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1048,80 +1005,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf2_kna", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "cs_input_version_original", "mets_hpa", "ssf22_snq", "lvi", "ssf14_sni", "mets_eval_ina", "ajcc_tdescriptor_cleanup", "ssf4_mna", "extension_eval_cna", "ajcc6_stage_qna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "grade", "summary_stage_rpa", "nodes_eval_ena", "ajcc7_m_codes", "ssf20_sno", "schema_selection_genital_male_other", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf1_jna", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ssf3_lna", "ss_codes", "ssf6_ona", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf10_sne", "ssf18_snm", "nodes_dca", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "extension_bcl", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/gist_appendix.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/gist_appendix.json
@@ -477,35 +477,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bfh",
@@ -600,32 +592,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -723,32 +707,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -850,11 +826,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "mitotic_rate_calculation_xpi",
@@ -897,8 +871,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -918,11 +891,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -937,11 +908,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1038,47 +1007,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1088,80 +1043,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf11_spk", "ssf25_snt", "mets_hch", "ajcc7_t_codes", "ssf23_snr", "histology", "extension_bfh", "cs_input_version_original", "ssf22_snq", "ssf1_jpv", "lvi", "ssf13_spm", "ajcc_tdescriptor_cleanup", "ssf4_mna", "ajcc6_stage_qna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "schema_selection_gist_appendix", "ajcc7_stage_upy", "grade", "ajcc7_inclusions_tpo", "summary_stage_rpa", "ajcc7_m_codes", "ssf12_spl", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "mitotic_rate_calculation_xpi", "nodes_dfd", "ssf15_spo", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf3_lna", "ss_codes", "ssf6_ona", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf14_spn", "ssf2_kph", "ssf10_sne", "mets_eval_ipc", "ssf18_snm", "ajcc7_n_codes", "size_apr", "ajcc6_stage_codes", "extension_eval_cpb", "ssf5_nna", "extension_size_ajcc7_xet", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epc", "cs_year_validation", "ssf24_sns", "ssf8_snc" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/gist_colon.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/gist_colon.json
@@ -477,35 +477,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bfe",
@@ -600,32 +592,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -723,32 +707,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -850,11 +826,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "mitotic_rate_calculation_xpi",
@@ -897,8 +871,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -918,11 +891,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -937,11 +908,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1038,47 +1007,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1088,80 +1043,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf11_spk", "ssf25_snt", "ajcc7_t_codes", "ssf23_snr", "extension_bfe", "histology", "cs_input_version_original", "ssf22_snq", "ssf1_jpv", "lvi", "ssf13_spm", "ajcc_tdescriptor_cleanup", "ssf4_mna", "ajcc6_stage_qna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "ajcc7_stage_upy", "schema_selection_gist_colon", "mets_hcb", "grade", "ajcc7_inclusions_tpo", "summary_stage_rpa", "ajcc7_m_codes", "ssf12_spl", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "mitotic_rate_calculation_xpi", "ssf15_spo", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf3_lna", "ss_codes", "ssf6_ona", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf14_spn", "nodes_dey", "ssf2_kph", "ssf10_sne", "mets_eval_ipc", "ssf18_snm", "ajcc7_n_codes", "size_apr", "ajcc6_stage_codes", "extension_eval_cpb", "ssf5_nna", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "primary_site", "ajcc6_year_validation", "extension_size_ajcc7_xeb", "ajcc6_m_codes", "nodes_eval_epc", "cs_year_validation", "ssf24_sns", "ssf8_snc" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/gist_esophagus.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/gist_esophagus.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bfn",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "mitotic_rate_calculation_xqe",
@@ -899,8 +873,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -920,11 +893,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -939,11 +910,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1040,47 +1009,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1090,80 +1045,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "mets_hcn", "ssf2_kna", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "extension_size_ajcc7_xfd", "histology", "extension_bfn", "cs_input_version_original", "ssf22_snq", "lvi", "ssf6_oph", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf4_mna", "mitotic_rate_calculation_xqe", "ajcc6_stage_qna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "ajcc7_stage_upy", "grade", "ajcc7_inclusions_tpo", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf10_srh", "ssf1_jna", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_sre", "nodes_dfj", "ssf11_snf", "ssf3_lna", "ss_codes", "schema_selection_gist_esophagus", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "size_api", "mets_eval_ipc", "ssf18_snm", "ajcc7_n_codes", "ajcc6_stage_codes", "extension_eval_cpb", "ssf5_nna", "ssf19_snn", "ajcc7_stage_codes", "ssf9_srg", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epc", "cs_year_validation", "ssf24_sns", "ssf8_srf", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/gist_peritoneum.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/gist_peritoneum.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bfu",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "mitotic_rate_calculation_xjm",
@@ -899,8 +873,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -920,11 +893,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -943,11 +914,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpi",
@@ -989,11 +958,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1004,8 +971,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1094,47 +1060,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1144,80 +1096,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "extension_bfu", "ajcc6_exclusions_ppc", "ssf2_kna", "ssf9_sdq", "extension_size_ajcc7_xfp", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "ssf8_sdp", "mets_hcs", "cs_input_version_original", "ajcctnm7_stage_giststomach_xit", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf4_mna", "ssf7_sdo", "schema_selection_gist_peritoneum", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "ajcc7_stage_upy", "grade", "ajcc7_inclusions_tpo", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ssf10_sqj", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf1_jna", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf11_snf", "ssf3_lna", "ss_codes", "nodes_exam_gpa", "ssf6_oas", "ajcc6_n_codes", "behavior", "ssf18_snm", "ajcc6_stage_qpi", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "size_aps", "ajcc6_stage_codes", "ssf5_nav", "ssf19_snn", "ajcc7_stage_codes", "ssf13_snh", "primary_site", "ajcc6_year_validation", "nodes_dfp", "mitotic_rate_calculation_xjm", "extension_size_ajcc6_xir", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/gist_rectum.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/gist_rectum.json
@@ -477,35 +477,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bff",
@@ -600,32 +592,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -723,32 +707,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -850,11 +826,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "mitotic_rate_calculation_xpi",
@@ -897,8 +871,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -918,11 +891,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -937,11 +908,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1038,47 +1007,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1088,80 +1043,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "mets_hcc", "ssf11_spk", "ssf25_snt", "ajcc7_t_codes", "extension_bff", "ssf23_snr", "histology", "cs_input_version_original", "ssf22_snq", "ssf1_jpv", "lvi", "ssf13_spm", "ajcc_tdescriptor_cleanup", "ssf4_mna", "ajcc6_stage_qna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "ajcc7_stage_upy", "grade", "ajcc7_inclusions_tpo", "summary_stage_rpa", "ajcc7_m_codes", "ssf12_spl", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "mitotic_rate_calculation_xpi", "ssf15_spo", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf3_lna", "ss_codes", "schema_selection_gist_rectum", "ssf6_ona", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf14_spn", "ssf2_kph", "ssf10_sne", "mets_eval_ipc", "nodes_dez", "ssf18_snm", "ajcc7_n_codes", "size_apr", "ajcc6_stage_codes", "extension_eval_cpb", "ssf5_nna", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "primary_site", "ajcc6_year_validation", "extension_size_ajcc7_xec", "ajcc6_m_codes", "nodes_eval_epc", "cs_year_validation", "ssf24_sns", "ssf8_snc" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/gist_small_intestine.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/gist_small_intestine.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bfd",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "site", "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "mitotic_rate_calculation_xqe",
@@ -899,8 +873,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -920,11 +893,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -939,11 +910,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1040,47 +1009,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1090,80 +1045,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf2_kna", "ssf25_snt", "mets_hce", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "extension_bfd", "histology", "cs_input_version_original", "ajcc7_inclusions_tql", "ssf22_snq", "lvi", "ssf6_oph", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf4_mna", "mitotic_rate_calculation_xqe", "ajcc6_stage_qna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "ajcc7_stage_upy", "grade", "summary_stage_rpa", "schema_selection_gist_small_intestine", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf10_srh", "nodes_dfb", "ssf1_jna", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_sre", "ssf11_snf", "ssf3_lna", "ss_codes", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "mets_eval_ipc", "ssf18_snm", "ajcc7_n_codes", "size_aps", "ajcc6_stage_codes", "extension_eval_cpb", "ssf5_nna", "ssf19_snn", "ajcc7_stage_codes", "ssf9_srg", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epc", "cs_year_validation", "ssf24_sns", "extension_size_ajcc7_xef", "ssf8_srf", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/gist_stomach.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/gist_stomach.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bfc",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "mitotic_rate_calculation_xqe",
@@ -898,8 +872,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -919,11 +892,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -938,11 +909,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1039,47 +1008,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1089,80 +1044,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf2_kna", "ssf25_snt", "mets_hcd", "ajcc7_stage_uap", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "cs_input_version_original", "size_aax", "ssf22_snq", "lvi", "ssf6_oph", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf4_mna", "mitotic_rate_calculation_xqe", "ajcc6_stage_qna", "ajcc7_year_validation", "ssf21_snp", "extension_bfc", "ssf17_snl", "ajcc_descriptor_codes", "grade", "ajcc7_inclusions_tpo", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf10_srh", "nodes_dfa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_sre", "ssf11_snf", "ssf3_lna", "ss_codes", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "mets_eval_ipc", "ssf1_jbm", "ssf18_snm", "ajcc7_n_codes", "ajcc6_stage_codes", "extension_eval_cpb", "ssf5_nna", "ssf19_snn", "ajcc7_stage_codes", "ssf9_srg", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "schema_selection_gist_stomach", "nodes_eval_epc", "cs_year_validation", "extension_size_ajcc7_xed", "ssf24_sns", "ssf8_srf", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/gum_lower.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/gum_lower.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bdl",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upt",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -938,11 +909,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpk",
@@ -984,11 +953,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -999,8 +966,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1089,47 +1055,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1139,80 +1091,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ajcc6_exclusions_ppd", "ssf1_jpa", "ssf25_snt", "nodes_ddh", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "mets_hpb", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpb", "ssf17_snl", "lymph_nodes_size_xpg", "ajcc_descriptor_codes", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_stage_upt", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "schema_selection_gum_lower", "nodes_exam_gpa", "size_apc", "extension_size_xpb", "ajcc6_n_codes", "extension_bdl", "behavior", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ajcc6_stage_qpk", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/gum_other.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/gum_other.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bdn",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upt",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -938,11 +909,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpk",
@@ -984,11 +953,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -999,8 +966,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1089,47 +1055,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1139,80 +1091,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ajcc6_exclusions_ppd", "ssf1_jpa", "ssf25_snt", "extension_size_xjg", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "mets_hpb", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpb", "ssf17_snl", "nodes_dad", "lymph_nodes_size_xpg", "ajcc_descriptor_codes", "schema_selection_gum_other", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_stage_upt", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "nodes_exam_gpa", "size_apc", "ajcc6_n_codes", "behavior", "extension_bdn", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ajcc6_stage_qpk", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/gum_upper.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/gum_upper.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bdm",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upt",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -938,11 +909,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpk",
@@ -984,11 +953,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -999,8 +966,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1089,47 +1055,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1139,80 +1091,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ajcc6_exclusions_ppd", "ssf1_jpa", "ssf25_snt", "ssf15_snj", "nodes_ddi", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "mets_hpb", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpb", "ssf17_snl", "lymph_nodes_size_xpg", "ajcc_descriptor_codes", "schema_selection_gum_upper", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_stage_upt", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "nodes_exam_gpa", "size_apc", "extension_size_xpb", "extension_bdm", "ajcc6_n_codes", "behavior", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ajcc6_stage_qpk", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/heart_mediastinum.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/heart_mediastinum.json
@@ -480,35 +480,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bbt",
@@ -603,32 +595,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -726,32 +710,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -853,11 +829,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ssf1_jpm",
@@ -900,8 +874,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -921,11 +894,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -944,11 +915,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpi",
@@ -990,11 +959,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1005,8 +972,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1095,47 +1061,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1145,80 +1097,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ajcc6_exclusions_ppc", "ajcc7_inclusions_tps", "extension_bbt", "ssf3_lpk", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf1_jpm", "histology", "cs_input_version_original", "mets_hpc", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "extension_size_xqj", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_stage_upm", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ajcc6_t_codes", "nodes_pos_fpa", "nodes_dbk", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ss_codes", "ssf6_ona", "nodes_exam_gpa", "schema_selection_heart_mediastinum", "ajcc6_n_codes", "ssf2_kpk", "behavior", "ssf10_sne", "ssf18_snm", "ajcc6_stage_qpi", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "size_apu", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "ssf4_mpf", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/heme_retic.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/heme_retic.json
@@ -482,35 +482,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bci",
@@ -605,32 +597,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -728,32 +712,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -857,8 +833,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -878,11 +853,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -897,11 +870,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -998,47 +969,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1048,80 +1005,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf2_kna", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "size_ana", "cs_input_version_original", "nodes_exam_gna", "ssf22_snq", "lvi", "ssf14_sni", "mets_eval_ina", "ajcc_tdescriptor_cleanup", "ssf4_mna", "extension_eval_cna", "ajcc6_stage_qna", "ajcc7_year_validation", "ssf21_snp", "schema_selection_heme_retic", "ssf17_snl", "ajcc_descriptor_codes", "nodes_pos_fna", "grade", "summary_stage_rpa", "nodes_eval_ena", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ajcc6_t_codes", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ssf3_lna", "ss_codes", "ssf6_ona", "ajcc6_n_codes", "mets_hna", "behavior", "nodes_dna", "ssf10_sne", "ssf18_snm", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ssf1_jbt", "ssf19_snn", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "cs_year_validation", "extension_bci", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/hypopharynx.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/hypopharynx.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bar",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upt",
@@ -895,8 +869,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -916,11 +889,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -939,11 +910,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpk",
@@ -985,11 +954,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1000,8 +967,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1090,47 +1056,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1140,80 +1092,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ajcc6_exclusions_ppd", "ssf1_jpa", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "ssf6_opa", "ssf3_lpa", "nodes_dco", "cs_input_version_original", "mets_hpb", "size_aay", "ssf22_snq", "lvi", "ssf14_sni", "extension_bar", "ajcc_tdescriptor_cleanup", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpb", "ssf17_snl", "lymph_nodes_size_xpg", "ajcc_descriptor_codes", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_stage_upt", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf11_snf", "ss_codes", "schema_selection_hypopharynx", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ajcc6_stage_qpk", "ssf13_snh", "primary_site", "ajcc6_year_validation", "extension_size_xbq", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/ill_defined_other.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/ill_defined_other.json
@@ -482,35 +482,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bna",
@@ -605,32 +597,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -728,32 +712,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -857,8 +833,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -878,11 +853,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -897,11 +870,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -998,47 +969,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1048,80 +1005,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf2_kna", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "cs_input_version_original", "nodes_exam_gna", "ssf22_snq", "lvi", "ssf14_sni", "mets_eval_ina", "ajcc_tdescriptor_cleanup", "ssf4_mna", "extension_bna", "extension_eval_cna", "ajcc6_stage_qna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "nodes_pos_fna", "grade", "summary_stage_rpa", "nodes_eval_ena", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf1_jna", "ajcc6_t_codes", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ssf3_lna", "ss_codes", "schema_selection_ill_defined_other", "ssf6_ona", "size_apa", "ajcc6_n_codes", "mets_hna", "behavior", "nodes_dna", "ssf10_sne", "ssf18_snm", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/intracranial_gland.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/intracranial_gland.json
@@ -481,35 +481,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bfy",
@@ -604,32 +596,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -727,32 +711,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -856,8 +832,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -877,11 +852,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -896,11 +869,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -997,47 +968,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1047,80 +1004,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "extension_bfy", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "ssf1_jpo", "cs_input_version_original", "mets_hpa", "nodes_exam_gna", "ssf22_snq", "lvi", "ssf14_sni", "mets_eval_ina", "ajcc_tdescriptor_cleanup", "ssf4_mna", "extension_eval_cna", "ajcc6_stage_qna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "nodes_pos_fna", "grade", "summary_stage_rpa", "nodes_eval_ena", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ajcc6_t_codes", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ssf3_lna", "ss_codes", "schema_selection_intracranial_gland", "ssf6_ona", "size_apa", "ajcc6_n_codes", "ssf2_kpl", "behavior", "ssf10_sne", "ssf18_snm", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ssf9_snd", "ssf13_snh", "primary_site", "nodes_dfu", "ajcc6_year_validation", "ajcc6_m_codes", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/kaposi_sarcoma.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/kaposi_sarcoma.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bcj",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -854,8 +830,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -875,11 +850,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -894,11 +867,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -995,47 +966,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1045,80 +1002,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf25_snt", "ssf4_mbh", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf1_jpj", "histology", "size_ana", "cs_input_version_original", "ssf22_snq", "lvi", "ssf14_sni", "mets_eval_ina", "ajcc_tdescriptor_cleanup", "ssf2_kbv", "extension_eval_cna", "ajcc6_stage_qna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "grade", "summary_stage_rpa", "schema_selection_kaposi_sarcoma", "nodes_eval_ena", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf3_laz", "ssf7_snb", "ssf11_snf", "ss_codes", "ssf6_ona", "nodes_exam_gpa", "ajcc6_n_codes", "mets_hna", "behavior", "ssf10_sne", "ssf18_snm", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_dby", "extension_bcj", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/kidney_parenchyma.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/kidney_parenchyma.json
@@ -480,35 +480,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bbp",
@@ -603,32 +595,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -726,32 +710,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -853,11 +829,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_uaw",
@@ -896,8 +870,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -917,11 +890,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -940,11 +911,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qal",
@@ -986,11 +955,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1001,8 +968,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1091,47 +1057,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1141,80 +1093,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "extension_bbp", "ajcc7_stage_uaw", "ajcc6_exclusions_ppd", "ssf2_kar", "ssf25_snt", "mets_hcg", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "size_aao", "histology", "cs_input_version_original", "ssf22_snq", "lvi", "ssf14_sni", "extension_size_table_ajcc7_xek", "ajcc_tdescriptor_cleanup", "ssf4_mam", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpb", "ssf17_snl", "ajcc_descriptor_codes", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ajcc6_stage_qal", "ssf16_snk", "ssf6_oaf", "ajcc6_t_codes", "nodes_pos_fpa", "extension_size_table_ajcc6_xal", "ajcc_mdescriptor_cleanup", "ssf11_snf", "nodes_dbg", "ss_codes", "nodes_exam_gpa", "ajcc6_n_codes", "ssf8_sby", "ssf1_jbd", "ssf3_lah", "behavior", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ssf7_sbx", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf5_nai", "ssf12_sng", "schema_selection_kidney_parenchyma" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/kidney_renal_pelvis.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/kidney_renal_pelvis.json
@@ -482,35 +482,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bbn",
@@ -605,32 +597,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -728,32 +712,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -855,11 +831,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upz",
@@ -898,8 +872,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -919,11 +892,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -942,11 +913,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qao",
@@ -988,11 +957,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1003,8 +970,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1093,47 +1059,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1143,80 +1095,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ajcc6_exclusions_ppd", "ssf25_snt", "ssf1_jpd", "ssf2_kaj", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "cs_input_version_original", "extension_bbn", "ssf22_snq", "mets_hpe", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf4_mna", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpb", "ssf17_snl", "ajcc_descriptor_codes", "ajcc7_stage_upz", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ajcc6_stage_qao", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "nodes_dbe", "ssf7_snb", "ssf11_snf", "ssf3_lna", "ss_codes", "ssf6_ona", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "schema_selection_kidney_renal_pelvis", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/lacrimal_gland.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/lacrimal_gland.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bct",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ssf25_spp",
@@ -898,8 +872,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -919,11 +892,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -942,11 +913,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ssf25_spp",
@@ -992,11 +961,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1007,8 +974,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1097,47 +1063,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1147,80 +1099,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf2_kax", "ajcc6_exclusions_ppd", "ajcc7_stage_unb", "ssf15_snj", "ajcc7_t_codes", "size_aan", "ssf23_snr", "nodes_dpa", "histology", "cs_input_version_original", "mets_hpc", "ssf22_snq", "lvi", "ssf14_sni", "schema_selection_lacrimal_gland", "ajcc_tdescriptor_cleanup", "ajcc6_stage_qnb", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpb", "ssf17_snl", "ajcc_descriptor_codes", "ssf4_maj", "ssf25_spp", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf6_oae", "ssf3_lba", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf8_sfk", "ssf11_snf", "ss_codes", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf1_jbj", "ssf10_sne", "extension_bct", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf7_sbv", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "extension_size_ajcc7_xej", "cs_year_validation", "ssf5_nah", "extension_size_ajcc6_xat", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/lacrimal_sac.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/lacrimal_sac.json
@@ -483,35 +483,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_btb",
@@ -606,32 +598,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -729,32 +713,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -858,8 +834,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -879,11 +854,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -902,11 +875,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ssf25_spp",
@@ -952,11 +923,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -967,8 +936,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1057,47 +1025,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1107,80 +1061,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf2_kna", "ajcc6_exclusions_ppd", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "cs_input_version_original", "size_aaz", "ssf22_snq", "schema_selection_lacrimal_sac", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf4_mna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "mets_eval_iae", "ajcc_descriptor_codes", "mets_hca", "ssf25_spp", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "extension_eval_cal", "ajcc_ndescriptor_cleanup", "ssf16_snk", "nodes_eval_eaj", "ssf1_jna", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ssf3_lna", "ss_codes", "ssf6_ona", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "nodes_dex", "ssf10_sne", "ssf18_snm", "extension_size_ajcc6_xea", "extension_btb", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ssf9_snd", "ssf13_snh", "ajcc6_stage_qpj", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/larynx_glottic.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/larynx_glottic.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bat",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_ubk",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -938,11 +909,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qbl",
@@ -984,11 +953,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -999,8 +966,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1089,47 +1055,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1139,80 +1091,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ajcc6_exclusions_ppd", "ssf1_jpa", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "ssf6_opa", "ssf3_lpa", "nodes_dcp", "cs_input_version_original", "mets_hpb", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "extension_bat", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpb", "ssf17_snl", "lymph_nodes_size_xpg", "ajcc_descriptor_codes", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf11_snf", "ss_codes", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ajcc6_stage_qbl", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "schema_selection_larynx_glottic", "ssf19_snn", "ajcc7_stage_codes", "ssf13_snh", "ajcc7_stage_ubk", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/larynx_other.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/larynx_other.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_baw",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "site", "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upt",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -938,11 +909,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpk",
@@ -984,11 +953,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -999,8 +966,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1089,47 +1055,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1139,80 +1091,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ajcc6_exclusions_ppd", "ssf1_jpa", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "nodes_dcr", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "mets_hpb", "ssf22_snq", "ajcc7_inclusions_tqm", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "extension_baw", "ssf17_snl", "lymph_nodes_size_xpg", "ajcc_descriptor_codes", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_stage_upt", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf11_snf", "ss_codes", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf18_snm", "mets_eval_ipa", "schema_selection_larynx_other", "extension_eval_cpa", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ajcc6_stage_qpk", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/larynx_subglottic.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/larynx_subglottic.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bav",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upt",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -938,11 +909,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpk",
@@ -984,11 +953,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -999,8 +966,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1089,47 +1055,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1139,80 +1091,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ajcc6_exclusions_ppd", "ssf1_jpa", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "mets_hpb", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "extension_bav", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpb", "ssf17_snl", "lymph_nodes_size_xpg", "ajcc_descriptor_codes", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_stage_upt", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "schema_selection_larynx_subglottic", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf11_snf", "ss_codes", "nodes_dap", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ajcc6_stage_qpk", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/larynx_supraglottic.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/larynx_supraglottic.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bau",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upt",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -938,11 +909,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpk",
@@ -984,11 +953,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -999,8 +966,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1089,47 +1055,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1139,80 +1091,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ajcc6_exclusions_ppd", "ssf1_jpa", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "nodes_dcq", "ssf23_snr", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "mets_hpb", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "extension_bau", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpb", "ssf17_snl", "lymph_nodes_size_xpg", "ajcc_descriptor_codes", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_stage_upt", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf11_snf", "ss_codes", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "schema_selection_larynx_supraglottic", "behavior", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ajcc6_stage_qpk", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/lip_lower.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/lip_lower.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bab",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upt",
@@ -895,8 +869,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -916,11 +889,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -939,11 +910,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpk",
@@ -985,11 +954,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1000,8 +967,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1090,47 +1056,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1140,80 +1092,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ajcc6_exclusions_ppd", "ssf1_jpa", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "mets_hpb", "ssf22_snq", "lvi", "ssf14_sni", "nodes_daa", "ajcc_tdescriptor_cleanup", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpb", "ssf17_snl", "lymph_nodes_size_xpg", "ajcc_descriptor_codes", "extension_bab", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_stage_upt", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "extension_size_xpa", "ss_codes", "nodes_exam_gpa", "size_apc", "ajcc6_n_codes", "schema_selection_lip_lower", "behavior", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ajcc6_stage_qpk", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/lip_other.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/lip_other.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bdj",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upt",
@@ -895,8 +869,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -916,11 +889,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -939,11 +910,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpk",
@@ -985,11 +954,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1000,8 +967,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1090,47 +1056,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1140,80 +1092,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "extension_size_xjh", "ajcc6_exclusions_ppd", "ssf1_jpa", "ssf25_snt", "nodes_ddg", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "schema_selection_lip_other", "mets_hpb", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpb", "ssf17_snl", "lymph_nodes_size_xpg", "ajcc_descriptor_codes", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_stage_upt", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "nodes_exam_gpa", "size_apc", "ajcc6_n_codes", "extension_bdj", "behavior", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ajcc6_stage_qpk", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/lip_upper.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/lip_upper.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bdc",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upt",
@@ -895,8 +869,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -916,11 +889,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -939,11 +910,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpk",
@@ -985,11 +954,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1000,8 +967,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1090,47 +1056,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1140,80 +1092,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "nodes_ddd", "ajcc6_exclusions_ppd", "ssf1_jpa", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "mets_hpb", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpb", "ssf17_snl", "ajcc_descriptor_codes", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_stage_upt", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "extension_size_xpa", "ss_codes", "extension_bdc", "nodes_exam_gpa", "size_apc", "ajcc6_n_codes", "behavior", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "lymph_nodes_size_xja", "ajcc6_stage_qpk", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "schema_selection_lip_upper", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/liver.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/liver.json
@@ -482,35 +482,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bbc",
@@ -605,32 +597,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -728,32 +712,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -855,11 +831,9 @@
       "inputs" : [ "site", "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_ubl",
@@ -898,8 +872,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -919,11 +892,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -942,11 +913,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qcc",
@@ -988,11 +957,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1003,8 +970,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1093,47 +1059,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1143,80 +1095,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf3_lps", "ajcc6_exclusions_ppd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "extension_bbc", "ssf23_snr", "ssf7_scb", "histology", "cs_input_version_original", "ssf1_jpw", "ssf22_snq", "lvi", "ssf14_sni", "schema_selection_liver", "ssf8_scc", "ajcc_tdescriptor_cleanup", "ajcc7_year_validation", "ssf21_snp", "ssf4_mal", "ssf17_snl", "ajcc_descriptor_codes", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ajcc7_inclusions_tpn", "ssf6_oag", "lymph_nodes_metsat_dxajcc6_xew", "ajcc6_t_codes", "ajcc6_stage_qcc", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "mets_haf", "ssf11_snf", "ss_codes", "nodes_exam_gpa", "ssf2_kpq", "ajcc6_n_codes", "behavior", "nodes_dau", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "ajcc7_n_codes", "extension_eval_cpc", "ajcc6_stage_codes", "size_apt", "ssf19_snn", "ajcc7_stage_codes", "extension_size_ajcc7_xev", "ssf9_snd", "ssf13_snh", "ssf5_nak", "primary_site", "ajcc7_stage_ubl", "ajcc6_year_validation", "extension_size_ajcc6_xak", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/lung.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/lung.json
@@ -482,35 +482,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_baj",
@@ -593,32 +585,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -704,32 +688,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -831,11 +807,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_ubq",
@@ -874,8 +848,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -895,11 +868,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -918,11 +889,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qab",
@@ -964,11 +933,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -979,8 +946,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1069,47 +1035,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1119,80 +1071,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "size_extension_mets_ssf1_ajcc6_xjp_t", "size_extension_mets_ssf1_ajcc6_xjt_m", "size_extension_mets_ssf1_ajcc6_xjp_m", "determine_correct_table_for_ajcc7_t_ns43", "size_extension_mets_ssf1_ajcc6_xjx_t", "ssf25_snt", "size_extension_mets_ssf1_ajcc6_xjt_t", "size_extension_mets_ssf1_ajcc6_xjx_m", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "extension_ssf1_summary_stage77_xkc", "extension_ssf1_summary_stage77_xkd", "histology", "cs_input_version_original", "lvi", "ajcc_tdescriptor_cleanup", "ssf1_sbh", "ssf21_snp", "nodes_dai", "extension_mets_ssf1_ajcc6_xjo_m", "ssf17_snl", "extension_eval_cae", "extension_mets_ssf1_ajcc6_xjo_t", "grade", "extension_baj", "determine_correct_table_for_ss77t_ns45", "size_extension_mets_ssf1_ajcc6_xjw_m", "extension_ssf1_summary_stage2000_xkf", "extension_ssf1_summary_stage2000_xke", "size_extension_mets_ssf1_ajcc6_xjs_m", "size_extension_mets_ssf1_ajcc6_xjw_t", "ajcc6_t_codes", "mets_hab", "determine_correct_table_for_ajcc6_tm_ns47", "nodes_pos_fpa", "size_extension_mets_ssf1_ajcc6_xjs_t", "determine_correct_table_for_ajcc6_tm_ns44", "nodes_eval_eag", "ssf11_snf", "ssf3_lna", "ssf6_ona", "ajcc6_n_codes", "behavior", "ssf18_snm", "mets_eval_ipa", "schema_selection_lung", "ajcc6_stage_codes", "ajcc7_stage_codes", "ssf13_snh", "ajcc6_m_codes", "ssf24_sns", "ssf8_snc", "size_extension_mets_ssf1_ajcc6_xjv_m", "size_aaa", "size_extension_mets_ssf1_ajcc6_xjr_m", "ajcc6_stage_qab", "size_extension_mets_ssf1_ajcc6_xjv_t", "size_extension_mets_ssf1_ajcc6_xjr_t", "determine_correct_table_for_ss00t_ns46", "ssf22_snq", "ssf14_sni", "ssf4_mna", "ssf2_sbi", "ajcc7_year_validation", "ajcc7_inclusions_tpb", "ajcc_descriptor_codes", "invalid_lung_m_values_ns49", "size_extension_ssf1_ajcc7_t_xjz", "extension_ssf1_ajcc7_t_xjy", "summary_stage_rpa", "ajcc7_m_codes", "size_extension_ssf1_ajcc7_t_xka", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "size_extension_mets_ssf1_ajcc6_xju_m", "size_extension_mets_ssf1_ajcc6_xjq_m", "size_extension_mets_ssf1_ajcc6_xju_t", "ajcc_mdescriptor_cleanup", "size_extension_mets_ssf1_ajcc6_xjq_t", "ssf7_snb", "ss_codes", "ajcc6_exclusions_paa", "nodes_exam_gpa", "size_metsat_dxajcc7_m_xkb", "ssf10_sne", "ajcc7_n_codes", "ssf5_nna", "ssf19_snn", "ajcc7_stage_ubq", "ssf9_snd", "primary_site", "ajcc6_year_validation", "determine_correct_table_for_m_ns48", "cs_year_validation", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/lymphoma.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/lymphoma.json
@@ -480,35 +480,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bch",
@@ -603,32 +595,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -726,32 +710,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -853,11 +829,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_ubw",
@@ -886,8 +860,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -907,11 +880,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -926,11 +897,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpo",
@@ -1017,47 +986,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1067,80 +1022,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "size_aaf", "ssf25_snt", "ssf3_lph", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf1_jpj", "histology", "cs_input_version_original", "nodes_exam_gna", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ajcc7_year_validation", "schema_selection_lymphoma", "ssf21_snp", "ssf5_npe", "ssf17_snl", "ajcc_descriptor_codes", "extension_eval_caf", "mets_eval_iaa", "nodes_pos_fna", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_inclusions_tpr", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpg", "ajcc6_t_codes", "nodes_eval_eaf", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ss_codes", "ssf6_ona", "ajcc6_n_codes", "mets_hna", "behavior", "nodes_dna", "ssf10_sne", "ssf18_snm", "ajcc7_n_codes", "ajcc7_stage_ubw", "ajcc6_stage_codes", "ajcc6_stage_qpo", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "extension_bch", "ajcc6_m_codes", "cs_year_validation", "ssf4_mpd", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/lymphoma_ocular_adnexa.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/lymphoma_ocular_adnexa.json
@@ -473,35 +473,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bez",
@@ -596,32 +588,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -719,32 +703,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -846,11 +822,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_unb",
@@ -889,8 +863,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -910,11 +883,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -929,11 +900,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "determine_correct_table_for_ajcc6_stg_ns15",
@@ -1020,47 +989,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1070,80 +1025,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ajcc6_stage_qdy", "ssf13_seg", "summary_stage_raa", "ssf25_snt", "ajcc7_stage_unb", "ssf4_mbj", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf1_jpj", "histology", "ssf12_sef", "cs_input_version_original", "size_aaw", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ajcc_tnm6_stage_csv1_xie", "extension_bez", "ssf11_see", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "mets_eval_iad", "determine_correct_table_for_ajcc6_stg_ns15", "grade", "ajcc7_m_codes", "ssf20_sno", "ajcc7_inclusions_tpl", "ajcc_ndescriptor_cleanup", "extension_eval_cak", "ssf16_snk", "mets_hby", "ssf2_kpg", "nodes_eval_eai", "schema_selection_lymphoma_ocular_adnexa", "ssf7_saq", "ssf10_sat", "ssf3_lbc", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "nodes_dev", "ssf6_oat", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf18_snm", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf9_sas", "ssf19_snn", "ajcc7_stage_codes", "primary_site", "ajcc6_year_validation", "ssf8_sar", "ajcc6_m_codes", "ssf5_nac", "cs_year_validation", "ssf24_sns" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_buccal_mucosa.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_buccal_mucosa.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_ben",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upu",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -934,11 +905,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1035,47 +1004,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1085,80 +1040,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "ssf1_jpu", "mets_hpd", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ajcc6_stage_qna", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpa", "ssf17_snl", "ajcc_descriptor_codes", "nodes_dei", "ajcc7_stage_upu", "ssf5_npa", "grade", "extension_ben", "summary_stage_rpa", "ajcc7_m_codes", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "schema_selection_melanoma_buccal_mucosa", "behavior", "mets_eval_ipc", "ssf18_snm", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "extension_eval_cpb", "ssf19_snn", "ajcc7_stage_codes", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epc", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_choroid.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_choroid.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bda",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upv",
@@ -895,8 +869,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -916,11 +889,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -935,11 +906,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpx",
@@ -1036,47 +1005,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1086,80 +1041,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "extension_size_category_ajcc7_xpm", "ssf13_sqq", "ssf12_sqb", "ssf25_snt", "ssf3_lpj", "ssf8_spx", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ajcc6_stage_qpx", "ssf6_opd", "nodes_dpa", "histology", "ssf1_jpq", "cs_input_version_original", "tumor_size_category_ajcc7_xpk", "ssf22_snq", "lvi", "mets_hpg", "ajcc_tdescriptor_cleanup", "schema_selection_melanoma_choroid", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpa", "ssf17_snl", "ssf10_spz", "ssf5_npf", "ajcc_descriptor_codes", "ajcc7_stage_upv", "ssf11_sqa", "grade", "summary_stage_rpa", "ssf7_spw", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "tumor_size_pair_ajcc6_xpl", "nodes_exam_gpa", "size_apb", "ajcc6_n_codes", "behavior", "ssf2_kpj", "extension_size_pair_ajcc6_xpn", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "extension_bda", "ssf19_snn", "ajcc7_stage_codes", "size_metastasis_ajcc7_xpx", "ssf9_sqm", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "ssf14_sqr", "ssf4_mpe", "cs_year_validation", "ssf24_sns" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_ciliary_body.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_ciliary_body.json
@@ -480,35 +480,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bfq",
@@ -603,32 +595,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -726,32 +710,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -853,11 +829,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ssf25_sqc",
@@ -900,8 +874,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -921,11 +894,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -940,11 +911,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ssf25_sqc",
@@ -1045,47 +1014,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1095,80 +1050,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "extension_size_category_ajcc7_xpm", "ssf12_sqb", "ssf3_lpj", "ssf8_spx", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ajcc6_stage_qpx", "ssf6_opd", "nodes_dpa", "histology", "ssf1_jpq", "cs_input_version_original", "tumor_size_category_ajcc7_xpk", "ssf22_snq", "extension_bfq", "lvi", "mets_hpg", "ajcc_tdescriptor_cleanup", "ssf13_sdg", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpa", "ssf17_snl", "ssf10_spz", "ssf5_npf", "ajcc_descriptor_codes", "ajcc7_stage_upv", "ssf11_sqa", "grade", "summary_stage_rpa", "ssf7_spw", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf25_sqc", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "tumor_size_pair_ajcc6_xpl", "schema_selection_melanoma_ciliary_body", "nodes_exam_gpa", "size_apb", "ajcc6_n_codes", "behavior", "ssf2_kpj", "extension_size_pair_ajcc6_xpn", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ssf14_sdh", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "size_metastasis_ajcc7_xpx", "ssf9_sqm", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "ssf4_mpe", "cs_year_validation", "ssf24_sns" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_conjunctiva.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_conjunctiva.json
@@ -481,35 +481,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bcs",
@@ -604,32 +596,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -727,32 +711,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -854,11 +830,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_unb",
@@ -897,8 +871,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -918,11 +891,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -937,11 +908,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qnb",
@@ -1038,47 +1007,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1088,80 +1043,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf25_snt", "ajcc7_stage_unb", "ssf15_snj", "ajcc7_t_codes", "ssf2_kbi", "ssf23_snr", "nodes_dpa", "histology", "cs_input_version_original", "mets_hpc", "pathologic_eval_extension_thickness_ajcc6_xbt", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf4_mna", "ajcc6_stage_qnb", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpa", "ssf17_snl", "ajcc_descriptor_codes", "pathologic_eval_extension_thickness_ajcc7_xcb", "grade", "summary_stage_rpa", "ajcc7_m_codes", "eval_extension_t3_ajcc7_xgh", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf3_law", "ssf7_snb", "ssf11_snf", "determine_correct_table_for_ajcc6_t_ns16", "ss_codes", "ssf6_ona", "size_apa", "nodes_exam_gpa", "clinical_eval_extension_thickness_ajcc6_xbw", "ajcc6_n_codes", "behavior", "ssf10_sne", "ssf18_snm", "extension_bcs", "mets_eval_ipa", "clinical_eval_extension_quadrants_ajcc7_xca", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "schema_selection_melanoma_conjunctiva", "ssf1_jby", "ssf19_snn", "ajcc7_stage_codes", "determine_correct_table_for_ajcc7_t_ns17", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_epiglottis_anterior.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_epiglottis_anterior.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bed",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upu",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -934,11 +905,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1035,47 +1004,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1085,80 +1040,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "ssf1_jpu", "mets_hpd", "ssf22_snq", "lvi", "ssf14_sni", "schema_selection_melanoma_epiglottis_anterior", "ajcc_tdescriptor_cleanup", "ajcc6_stage_qna", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpa", "ssf17_snl", "ajcc_descriptor_codes", "extension_bed", "ajcc7_stage_upu", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "nodes_ddy", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "mets_eval_ipc", "ssf18_snm", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "extension_eval_cpb", "ssf19_snn", "ajcc7_stage_codes", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epc", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_eye_other.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_eye_other.json
@@ -482,35 +482,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bpb",
@@ -605,32 +597,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -728,32 +712,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -857,8 +833,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -878,11 +853,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -897,11 +870,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -998,47 +969,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1048,80 +1005,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf2_kna", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "cs_input_version_original", "mets_hpa", "nodes_dpb", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf4_mna", "ajcc6_stage_qna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "mets_eval_iaf", "ajcc_descriptor_codes", "grade", "extension_eval_cam", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "nodes_eval_eak", "schema_selection_melanoma_eye_other", "ssf1_jna", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ssf3_lna", "ss_codes", "ssf6_ona", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf10_sne", "ssf18_snm", "ajcc7_n_codes", "ajcc6_stage_codes", "extension_bpb", "ssf5_nna", "ssf19_snn", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_floor_mouth.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_floor_mouth.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_beo",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upu",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -934,11 +905,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1035,47 +1004,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1085,80 +1040,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "ssf1_jpu", "mets_hpd", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ajcc6_stage_qna", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpa", "ssf17_snl", "ajcc_descriptor_codes", "nodes_dej", "ajcc7_stage_upu", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "extension_beo", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "mets_eval_ipc", "ssf18_snm", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "extension_eval_cpb", "ssf19_snn", "ajcc7_stage_codes", "ssf13_snh", "primary_site", "ajcc6_year_validation", "schema_selection_melanoma_floor_mouth", "ajcc6_m_codes", "nodes_eval_epc", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_gum_lower.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_gum_lower.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bep",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upu",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -934,11 +905,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1035,47 +1004,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1085,80 +1040,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "ssf1_jpu", "mets_hpd", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ajcc6_stage_qna", "ssf9_spc", "nodes_dek", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpa", "ssf17_snl", "ajcc_descriptor_codes", "ajcc7_stage_upu", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf8_spb", "ssf20_sno", "extension_bep", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "schema_selection_melanoma_gum_lower", "ss_codes", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "mets_eval_ipc", "ssf18_snm", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "extension_eval_cpb", "ssf19_snn", "ajcc7_stage_codes", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epc", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_gum_other.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_gum_other.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_beq",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upu",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -934,11 +905,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1035,47 +1004,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1085,80 +1040,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "ssf1_jpu", "mets_hpd", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "schema_selection_melanoma_gum_other", "ajcc6_stage_qna", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "nodes_del", "ajcc7_inclusions_tpa", "ssf17_snl", "ajcc_descriptor_codes", "ajcc7_stage_upu", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf8_spb", "extension_beq", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "mets_eval_ipc", "ssf18_snm", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "extension_eval_cpb", "ssf19_snn", "ajcc7_stage_codes", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epc", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_gum_upper.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_gum_upper.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_ber",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upu",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -934,11 +905,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1035,47 +1004,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1085,80 +1040,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "ssf1_jpu", "mets_hpd", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ajcc6_stage_qna", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "nodes_dem", "ajcc7_inclusions_tpa", "ssf17_snl", "ajcc_descriptor_codes", "ajcc7_stage_upu", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "extension_ber", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "mets_eval_ipc", "ssf18_snm", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "extension_eval_cpb", "ssf19_snn", "ajcc7_stage_codes", "schema_selection_melanoma_gum_upper", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epc", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_hypopharynx.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_hypopharynx.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bee",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upu",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -934,11 +905,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1035,47 +1004,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1085,80 +1040,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "ssf1_jpu", "mets_hpd", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ajcc6_stage_qna", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpa", "ssf17_snl", "ajcc_descriptor_codes", "extension_bee", "ajcc7_stage_upu", "schema_selection_melanoma_hypopharynx", "ssf5_npa", "grade", "nodes_ddz", "summary_stage_rpa", "ajcc7_m_codes", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "mets_eval_ipc", "ssf18_snm", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "extension_eval_cpb", "ssf19_snn", "ajcc7_stage_codes", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epc", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_iris.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_iris.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bfr",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ssf25_sqc",
@@ -899,8 +873,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -920,11 +893,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -939,11 +910,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ssf25_sqc",
@@ -1044,47 +1013,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1094,80 +1049,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf3_lpr", "ssf13_sqq", "ssf12_sqb", "ssf8_spx", "ajcc6_stage_qea", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf6_opd", "nodes_dpa", "histology", "ssf1_jpq", "cs_input_version_original", "ajcc7_stage_uad", "schema_selection_melanoma_iris", "extension_bfr", "ssf22_snq", "lvi", "mets_hpg", "ajcc_tdescriptor_cleanup", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpa", "ssf2_kbm", "ssf17_snl", "ssf10_spz", "ssf5_npf", "ajcc_descriptor_codes", "ssf11_sqa", "grade", "summary_stage_rpa", "ssf7_spw", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf25_sqc", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "nodes_exam_gpa", "size_apb", "ajcc6_n_codes", "behavior", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "size_metastasis_ajcc7_xpx", "ssf9_sqm", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "ssf14_sqr", "ssf4_mpe", "cs_year_validation", "ssf24_sns" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_larynx_glottic.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_larynx_glottic.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bdv",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upu",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -934,11 +905,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1035,47 +1004,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1085,80 +1040,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "schema_selection_melanoma_larynx_glottic", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "ssf1_jpu", "mets_hpd", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ajcc6_stage_qna", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpa", "ssf17_snl", "ajcc_descriptor_codes", "ajcc7_stage_upu", "ssf5_npa", "nodes_ddq", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "extension_bdv", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "mets_eval_ipc", "ssf18_snm", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "extension_eval_cpb", "ssf19_snn", "ajcc7_stage_codes", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epc", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_larynx_other.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_larynx_other.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bdw",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upu",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -934,11 +905,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1035,47 +1004,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1085,80 +1040,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "ssf1_jpu", "mets_hpd", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ajcc6_stage_qna", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpa", "ssf17_snl", "ajcc_descriptor_codes", "nodes_ddr", "ajcc7_stage_upu", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "extension_bdw", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "mets_eval_ipc", "ssf18_snm", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "extension_eval_cpb", "ssf19_snn", "ajcc7_stage_codes", "ssf13_snh", "primary_site", "ajcc6_year_validation", "schema_selection_melanoma_larynx_other", "ajcc6_m_codes", "nodes_eval_epc", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_larynx_subglottic.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_larynx_subglottic.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bdx",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upu",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -934,11 +905,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1035,47 +1004,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1085,80 +1040,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "ssf1_jpu", "mets_hpd", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ajcc6_stage_qna", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpa", "ssf17_snl", "ajcc_descriptor_codes", "nodes_dds", "ajcc7_stage_upu", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "extension_bdx", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "schema_selection_melanoma_larynx_subglottic", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "mets_eval_ipc", "ssf18_snm", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "extension_eval_cpb", "ssf19_snn", "ajcc7_stage_codes", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epc", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_larynx_supraglottic.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_larynx_supraglottic.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bdy",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upu",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -934,11 +905,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1035,47 +1004,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1085,80 +1040,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "ssf1_jpu", "mets_hpd", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ajcc6_stage_qna", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpa", "ssf17_snl", "ajcc_descriptor_codes", "nodes_ddt", "ajcc7_stage_upu", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "extension_bdy", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "schema_selection_melanoma_larynx_supraglottic", "ajcc_mdescriptor_cleanup", "ss_codes", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "mets_eval_ipc", "ssf18_snm", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "extension_eval_cpb", "ssf19_snn", "ajcc7_stage_codes", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epc", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_lip_lower.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_lip_lower.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bes",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upu",
@@ -895,8 +869,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -916,11 +889,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -935,11 +906,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1036,47 +1005,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1086,80 +1041,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "ssf1_jpu", "mets_hpd", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "extension_bes", "ajcc6_stage_qna", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpa", "nodes_den", "ssf17_snl", "ajcc_descriptor_codes", "ajcc7_stage_upu", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "schema_selection_melanoma_lip_lower", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "mets_eval_ipc", "ssf18_snm", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "extension_eval_cpb", "ssf19_snn", "ajcc7_stage_codes", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epc", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_lip_other.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_lip_other.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bet",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upu",
@@ -895,8 +869,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -916,11 +889,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -935,11 +906,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1036,47 +1005,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1086,80 +1041,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "ssf1_jpu", "mets_hpd", "ssf22_snq", "lvi", "ssf14_sni", "extension_bet", "ajcc_tdescriptor_cleanup", "ajcc6_stage_qna", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpa", "ssf17_snl", "ajcc_descriptor_codes", "ajcc7_stage_upu", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "nodes_deo", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "mets_eval_ipc", "ssf18_snm", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "extension_eval_cpb", "ssf19_snn", "ajcc7_stage_codes", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epc", "cs_year_validation", "schema_selection_melanoma_lip_other", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_lip_upper.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_lip_upper.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bdt",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upu",
@@ -895,8 +869,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -916,11 +889,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -935,11 +906,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1036,47 +1005,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1086,80 +1041,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "ssf1_jpu", "mets_hpd", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ajcc6_stage_qna", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpa", "ssf17_snl", "ajcc_descriptor_codes", "ajcc7_stage_upu", "nodes_ddo", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "extension_bdt", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "mets_eval_ipc", "schema_selection_melanoma_lip_upper", "ssf18_snm", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "extension_eval_cpb", "ssf19_snn", "ajcc7_stage_codes", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epc", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_mouth_other.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_mouth_other.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bev",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upu",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -934,11 +905,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1035,47 +1004,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1085,80 +1040,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "ssf1_jpu", "mets_hpd", "ssf22_snq", "lvi", "ssf14_sni", "extension_bev", "ajcc_tdescriptor_cleanup", "ajcc6_stage_qna", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpa", "ssf17_snl", "ajcc_descriptor_codes", "ajcc7_stage_upu", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "size_apa", "nodes_exam_gpa", "nodes_deq", "ajcc6_n_codes", "behavior", "mets_eval_ipc", "ssf18_snm", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "extension_eval_cpb", "ssf19_snn", "ajcc7_stage_codes", "ssf13_snh", "primary_site", "ajcc6_year_validation", "schema_selection_melanoma_mouth_other", "ajcc6_m_codes", "nodes_eval_epc", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_nasal_cavity.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_nasal_cavity.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bei",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upu",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -934,11 +905,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1035,47 +1004,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1085,80 +1040,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "ssf1_jpu", "mets_hpd", "ssf22_snq", "lvi", "ssf14_sni", "nodes_ded", "ajcc_tdescriptor_cleanup", "ajcc6_stage_qna", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpa", "ssf17_snl", "ajcc_descriptor_codes", "ajcc7_stage_upu", "extension_bei", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "mets_eval_ipc", "ssf18_snm", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "extension_eval_cpb", "ssf19_snn", "ajcc7_stage_codes", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epc", "cs_year_validation", "ssf24_sns", "ssf12_sng", "schema_selection_melanoma_nasal_cavity" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_nasopharynx.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_nasopharynx.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bej",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upu",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -934,11 +905,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1035,47 +1004,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1085,80 +1040,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ssf25_snt", "schema_selection_melanoma_nasopharynx", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "ssf1_jpu", "mets_hpd", "ssf22_snq", "lvi", "ssf14_sni", "nodes_dee", "ajcc_tdescriptor_cleanup", "ajcc6_stage_qna", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpa", "ssf17_snl", "ajcc_descriptor_codes", "extension_bej", "ajcc7_stage_upu", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "mets_eval_ipc", "ssf18_snm", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "extension_eval_cpb", "ssf19_snn", "ajcc7_stage_codes", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epc", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_oropharynx.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_oropharynx.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bek",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upu",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -934,11 +905,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1035,47 +1004,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1085,80 +1040,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "ssf1_jpu", "mets_hpd", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "nodes_def", "ajcc6_stage_qna", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpa", "ssf17_snl", "ajcc_descriptor_codes", "ajcc7_stage_upu", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "extension_bek", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "schema_selection_melanoma_oropharynx", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "mets_eval_ipc", "ssf18_snm", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "extension_eval_cpb", "ssf19_snn", "ajcc7_stage_codes", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epc", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_palate_hard.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_palate_hard.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bew",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upu",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -934,11 +905,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1035,47 +1004,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1085,80 +1040,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "ssf1_jpu", "mets_hpd", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "schema_selection_melanoma_palate_hard", "ajcc6_stage_qna", "extension_bew", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpa", "ssf17_snl", "ajcc_descriptor_codes", "ajcc7_stage_upu", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "size_apa", "nodes_exam_gpa", "nodes_der", "ajcc6_n_codes", "behavior", "mets_eval_ipc", "ssf18_snm", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "extension_eval_cpb", "ssf19_snn", "ajcc7_stage_codes", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epc", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_palate_soft.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_palate_soft.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bel",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upu",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -934,11 +905,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1035,47 +1004,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1085,80 +1040,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "ssf1_jpu", "mets_hpd", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ajcc6_stage_qna", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpa", "ssf17_snl", "nodes_deg", "ajcc_descriptor_codes", "ajcc7_stage_upu", "ssf5_npa", "grade", "summary_stage_rpa", "extension_bel", "ajcc7_m_codes", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "mets_eval_ipc", "ssf18_snm", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "extension_eval_cpb", "ssf19_snn", "ajcc7_stage_codes", "schema_selection_melanoma_palate_soft", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epc", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_pharynx_other.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_pharynx_other.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bem",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upu",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -934,11 +905,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1035,47 +1004,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1085,80 +1040,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "schema_selection_melanoma_pharynx_other", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "ssf1_jpu", "mets_hpd", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ajcc6_stage_qna", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpa", "ssf17_snl", "ajcc_descriptor_codes", "ajcc7_stage_upu", "ssf5_npa", "grade", "extension_bem", "summary_stage_rpa", "ajcc7_m_codes", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "mets_eval_ipc", "ssf18_snm", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "extension_eval_cpb", "ssf19_snn", "ajcc7_stage_codes", "ssf13_snh", "nodes_dft", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epc", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_sinus_ethmoid.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_sinus_ethmoid.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_beg",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upu",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -934,11 +905,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1035,47 +1004,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1085,80 +1040,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "ssf1_jpu", "mets_hpd", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ajcc6_stage_qna", "nodes_deb", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpa", "ssf17_snl", "ajcc_descriptor_codes", "schema_selection_melanoma_sinus_ethmoid", "ajcc7_stage_upu", "ssf5_npa", "extension_beg", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "mets_eval_ipc", "ssf18_snm", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "extension_eval_cpb", "ssf19_snn", "ajcc7_stage_codes", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epc", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_sinus_maxillary.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_sinus_maxillary.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_beh",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upu",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -934,11 +905,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1035,47 +1004,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1085,80 +1040,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "ssf1_jpu", "mets_hpd", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ajcc6_stage_qna", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpa", "ssf17_snl", "ajcc_descriptor_codes", "ajcc7_stage_upu", "extension_beh", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "nodes_deu", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "mets_eval_ipc", "ssf18_snm", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "extension_eval_cpb", "ssf19_snn", "ajcc7_stage_codes", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epc", "cs_year_validation", "ssf24_sns", "ssf12_sng", "schema_selection_melanoma_sinus_maxillary" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_sinus_other.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_sinus_other.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_beb",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_una",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -934,11 +905,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1035,47 +1004,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1085,80 +1040,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ssf25_snt", "ajcc7_stage_una", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "ssf1_jpu", "ssf22_snq", "mets_hcx", "lvi", "ssf14_sni", "mets_eval_ina", "ajcc_tdescriptor_cleanup", "extension_eval_cna", "ajcc6_stage_qna", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpa", "ssf17_snl", "ajcc_descriptor_codes", "ssf5_npa", "grade", "summary_stage_rpa", "nodes_eval_ena", "ajcc7_m_codes", "ssf8_spb", "ssf20_sno", "nodes_ddw", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "extension_beb", "ajcc_mdescriptor_cleanup", "ss_codes", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf18_snm", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "schema_selection_melanoma_sinus_other", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_skin.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_skin.json
@@ -480,35 +480,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_ban",
@@ -603,32 +595,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -726,32 +710,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -853,11 +829,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_ubv",
@@ -896,8 +870,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -917,11 +890,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -936,11 +907,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qbq",
@@ -1037,47 +1006,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1087,80 +1042,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "nodes_pos_fah", "schema_selection_melanoma_skin", "determine_correct_table_for_ajcc7_n_ns40", "ssf25_snt", "summary_stage_rac", "ssf15_snj", "determine_correct_table_for_ajcc6_n_ns41", "ajcc7_t_codes", "ssf23_snr", "ssf1_jpl", "histology", "cs_input_version_original", "extension_thickness_ulceration_tcategory_ajcc6_xkj", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "metsat_dxand_ldh_xbs", "ssf3_laa", "ajcc7_year_validation", "extension_thickness_ulceration_tcategory_ajcc7_xkk", "ssf21_snp", "ajcc7_inclusions_tpa", "ssf17_snl", "ajcc_descriptor_codes", "lymph_nodeand_nodal_status_eval_blank_ajcc6_xlm", "thickness_ulceration_ajcc6_xbn", "nodes_eval_eba", "grade", "ajcc7_m_codes", "extension_ban", "ssf20_sno", "lymph_nodeand_nodal_status_eval_blank_ajcc7_xlj", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ajcc6_t_codes", "mets_had", "lymph_nodeand_nodal_status_pathologic_eval_ajcc6_xll", "ajcc_mdescriptor_cleanup", "ssf11_snf", "ssf6_oax", "ss_codes", "ssf7_seb", "size_apa", "nodes_dam", "ssf4_maa", "lymph_nodeand_nodal_status_pathologic_eval_ajcc7_xli", "lymph_nodeand_nodal_status_clinical_eval_ajcc6_xlk", "ajcc6_n_codes", "ajcc6_stage_qbq", "behavior", "ssf10_sne", "ssf8_sec", "ssf18_snm", "mets_eval_ipa", "ssf5_nba", "extension_eval_cpa", "ajcc7_n_codes", "thickness_ulceration_ajcc7_xhu", "ajcc6_stage_codes", "lymph_nodeand_nodal_status_clinical_eval_ajcc7_xlh", "nodes_exam_gaf", "ajcc7_stage_ubv", "ssf19_snn", "ajcc7_stage_codes", "ssf13_snh", "primary_site", "ajcc6_year_validation", "extension_ulceration_t1_ajcc6_xbo", "ssf9_sed", "ssf2_kaa", "ajcc6_m_codes", "cs_year_validation", "mitotic_rate_ulceration_t1_ajcc7_xgo", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_tongue_anterior.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_tongue_anterior.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bex",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upu",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -934,11 +905,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1035,47 +1004,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1085,80 +1040,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "ssf1_jpu", "mets_hpd", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "extension_bex", "ajcc6_stage_qna", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpa", "ssf17_snl", "ajcc_descriptor_codes", "ajcc7_stage_upu", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "nodes_des", "ss_codes", "size_apa", "schema_selection_melanoma_tongue_anterior", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "mets_eval_ipc", "ssf18_snm", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "extension_eval_cpb", "ssf19_snn", "ajcc7_stage_codes", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epc", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_tongue_base.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/melanoma_tongue_base.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bef",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upu",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -934,11 +905,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -1035,47 +1004,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1085,80 +1040,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "schema_selection_melanoma_tongue_base", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "ssf1_jpu", "mets_hpd", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "nodes_dea", "ajcc6_stage_qna", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpa", "ssf17_snl", "ajcc_descriptor_codes", "extension_bef", "ajcc7_stage_upu", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "mets_eval_ipc", "ssf18_snm", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "extension_eval_cpb", "ssf19_snn", "ajcc7_stage_codes", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epc", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/merkel_cell_penis.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/merkel_cell_penis.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bfz",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_uqe",
@@ -895,8 +869,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -916,11 +889,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -939,11 +910,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qps",
@@ -985,11 +954,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1000,8 +967,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1090,47 +1056,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1140,80 +1092,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "nodes_pos_fah", "ssf2_kna", "extension_bfz", "ajcc6_exclusions_ppd", "ssf3_lpq", "ssf25_snt", "ajcc7_inclusions_tqb", "ssf22_src", "ssf15_snj", "ajcc7_t_codes", "mets_hph", "ssf23_snr", "histology", "ajcc6_stage_qps", "cs_input_version_original", "ssf1_jpt", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf20_sra", "ssf4_mna", "ssf16_sqw", "ajcc7_year_validation", "ajcc7_stage_uqe", "ajcc_descriptor_codes", "ssf17_sqx", "nodes_eval_eba", "grade", "lymph_nodeand_nodal_status_eval_blank_ajcc7_xln", "summary_stage_rpa", "ajcc7_m_codes", "ssf21_srb", "ajcc_ndescriptor_cleanup", "ssf19_sqz", "ajcc6_t_codes", "ssf18_sqy", "schema_selection_merkel_cell_penis", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ss_codes", "ssf6_ona", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf10_sne", "mets_eval_ipa", "size_apo", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "nodes_dfv", "determine_correct_table_for_ajcc7_n_ns18", "ajcc6_m_codes", "cs_year_validation", "ssf24_sns", "lymph_nodeand_nodal_status_eval_ajcc7_xlg", "extension_size_ajcc7_xik", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/merkel_cell_scrotum.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/merkel_cell_scrotum.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bga",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_uqe",
@@ -895,8 +869,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -916,11 +889,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -939,11 +910,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpt",
@@ -985,11 +954,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1000,8 +967,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1090,47 +1056,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1140,80 +1092,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "extension_size_ajcc6_xji", "nodes_pos_fah", "ssf2_kna", "ajcc6_exclusions_ppd", "ssf3_lpq", "ssf25_snt", "ajcc7_inclusions_tqb", "ssf22_src", "extension_bga", "ssf15_snj", "ajcc7_t_codes", "mets_hph", "ssf23_snr", "histology", "ajcc6_stage_qpt", "cs_input_version_original", "ssf1_jpt", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf20_sra", "ssf4_mna", "ssf16_sqw", "ajcc7_year_validation", "ajcc7_stage_uqe", "ajcc_descriptor_codes", "ssf17_sqx", "nodes_eval_eba", "grade", "lymph_nodeand_nodal_status_eval_blank_ajcc7_xlo", "summary_stage_rpa", "ajcc7_m_codes", "ssf21_srb", "ajcc_ndescriptor_cleanup", "ssf19_sqz", "ajcc6_t_codes", "ssf18_sqy", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ss_codes", "ssf6_ona", "nodes_exam_gpa", "ajcc6_n_codes", "schema_selection_merkel_cell_scrotum", "behavior", "ssf10_sne", "mets_eval_ipa", "size_apo", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "lymph_nodeand_nodal_status_eval_ajcc7_xlb", "ajcc6_year_validation", "nodes_dfw", "determine_correct_table_for_ajcc7_n_ns19", "ajcc6_m_codes", "extension_size_ajcc7_xim", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/merkel_cell_skin.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/merkel_cell_skin.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bds",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_uqe",
@@ -895,8 +869,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -916,11 +889,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -939,11 +910,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qdx",
@@ -985,11 +954,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1000,8 +967,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1090,47 +1056,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1140,80 +1092,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "nodes_pos_fah", "ssf2_kna", "ajcc6_exclusions_ppd", "ajcc6_stage_qdx", "ssf3_lpq", "ssf25_snt", "ajcc7_inclusions_tqb", "ssf22_src", "schema_selection_merkel_cell_skin", "ssf15_snj", "ajcc7_t_codes", "mets_hph", "ssf23_snr", "histology", "cs_input_version_original", "ssf1_jpt", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf20_sra", "ssf4_mna", "ssf16_sqw", "ajcc7_year_validation", "ajcc7_stage_uqe", "ajcc_descriptor_codes", "nodes_ddn", "ssf17_sqx", "nodes_eval_eba", "lymph_nodeand_nodal_status_eval_blank_ajcc7_xlp", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf21_srb", "ajcc_ndescriptor_cleanup", "extension_bds", "extension_size_xdb", "ssf19_sqz", "ajcc6_t_codes", "ssf18_sqy", "ajcc_mdescriptor_cleanup", "determine_correct_table_for_ajcc7_n_ns20", "ssf7_snb", "ssf11_snf", "ss_codes", "ssf6_ona", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf10_sne", "mets_eval_ipa", "size_apo", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "cs_year_validation", "lymph_nodeand_nodal_status_eval_ajcc7_xle", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/merkel_cell_vulva.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/merkel_cell_vulva.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bgb",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_uqe",
@@ -895,8 +869,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -916,11 +889,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -939,11 +910,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpu",
@@ -985,11 +954,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1000,8 +967,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1090,47 +1056,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1140,80 +1092,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "nodes_pos_fah", "ssf2_kna", "ajcc6_exclusions_ppd", "ssf3_lpq", "ssf25_snt", "lymph_nodes_metsat_dxajcc6_xlf", "ajcc7_inclusions_tqb", "ssf22_src", "extension_bgb", "extension_size_ajcc6_xjj", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "ajcc6_stage_qpu", "cs_input_version_original", "ssf1_jpt", "lvi", "mets_hcy", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf20_sra", "ssf4_mna", "ssf16_sqw", "ajcc7_year_validation", "ajcc7_stage_uqe", "ajcc_descriptor_codes", "ssf17_sqx", "nodes_eval_eba", "lymph_nodeand_nodal_status_eval_blank_ajcc7_xlq", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf21_srb", "ajcc_ndescriptor_cleanup", "ssf19_sqz", "ajcc6_t_codes", "ssf18_sqy", "ajcc_mdescriptor_cleanup", "determine_correct_table_for_ajcc7_n_ns21", "ssf7_snb", "ss_codes", "ssf11_srd", "ssf6_ona", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf10_sne", "schema_selection_merkel_cell_vulva", "mets_eval_ipa", "size_apo", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "lymph_nodesand_ssf11_ajcc6_xiq", "lymph_nodeand_nodal_status_eval_ajcc7_xld", "ajcc6_m_codes", "cs_year_validation", "extension_size_ajcc7_xio", "nodes_dfx", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/middle_ear.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/middle_ear.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bcr",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -853,8 +829,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -874,11 +849,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -897,11 +870,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -943,11 +914,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -958,8 +927,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1048,47 +1016,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1098,80 +1052,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ajcc6_exclusions_ppd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "ssf1_jpu", "ssf22_snq", "lvi", "mets_hpf", "ssf14_sni", "mets_eval_ina", "ajcc_tdescriptor_cleanup", "extension_eval_cna", "ajcc6_stage_qna", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "ssf5_npa", "grade", "summary_stage_rpa", "nodes_eval_ena", "ajcc7_m_codes", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf11_snf", "ss_codes", "schema_selection_middle_ear", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf18_snm", "extension_bcr", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "ssf19_snn", "nodes_dcf", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/mouth_other.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/mouth_other.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_baf",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upt",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -938,11 +909,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpk",
@@ -984,11 +953,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -999,8 +966,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1089,47 +1055,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1139,80 +1091,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ajcc6_exclusions_ppd", "ssf1_jpa", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "schema_selection_mouth_other", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "mets_hpb", "ssf22_snq", "lvi", "nodes_dpd", "ssf14_sni", "ajcc_tdescriptor_cleanup", "extension_size_xad", "ssf9_spc", "lymph_nodes_size_xpd", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpb", "ssf17_snl", "ajcc_descriptor_codes", "extension_baf", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_stage_upt", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "nodes_exam_gpa", "size_apc", "ajcc6_n_codes", "behavior", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ajcc6_stage_qpk", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/mycosis_fungoides.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/mycosis_fungoides.json
@@ -482,35 +482,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bcp",
@@ -605,32 +597,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -728,32 +712,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -855,11 +831,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ssf1_jaj",
@@ -905,8 +879,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -926,11 +899,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -949,11 +920,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qbb",
@@ -995,11 +964,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1010,8 +977,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1100,47 +1066,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1150,80 +1102,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ajcc7_inclusions_tpw", "ssf2_kna", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "cs_input_version_original", "ssf22_snq", "lvi", "ssf14_sni", "size_aba", "ajcc_tdescriptor_cleanup", "ssf4_mna", "ajcc7_year_validation", "ssf21_snp", "ajcc6_stage_qbb", "ssf17_snl", "ajcc_descriptor_codes", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ssf1_jaj", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc6_exclusions_pak", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ssf3_lna", "ss_codes", "mets_haz", "ssf6_ona", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc7_stage_ubx", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "nodes_dce", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "extension_bcp", "ssf24_sns", "ssf8_snc", "ssf12_sng", "schema_selection_mycosis_fungoides" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/myeloma_plasma_cell_disorder.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/myeloma_plasma_cell_disorder.json
@@ -92,7 +92,6 @@
     "name" : "CS Lymph Nodes",
     "description" : "Identifies the regional lymph nodes involved with cancer at the time of diagnosis.",
     "naaccr_item" : 2830,
-    "default" : "*",
     "table" : "nodes_dfy",
     "used_for_staging" : true
   }, {
@@ -146,7 +145,6 @@
     "key" : "ssf2",
     "name" : "Durie-Salmon Staging System",
     "naaccr_item" : 2890,
-    "default" : "**",
     "table" : "ssf2_kbx",
     "used_for_staging" : false,
     "metadata" : [ "COC_CLINICALLY_SIGNIFICANT", "CCCR_IVB_COLLECT_IF_IN_CLINICAL_CHART", "SEER_CLINICALLY_SIGNIFICANT" ]
@@ -154,7 +152,6 @@
     "key" : "ssf3",
     "name" : "Multiple Myeloma Terminology",
     "naaccr_item" : 2900,
-    "default" : "**",
     "table" : "ssf3_lbb",
     "used_for_staging" : false,
     "metadata" : [ "COC_CLINICALLY_SIGNIFICANT", "CCCR_IVB_COLLECT_IF_IN_CLINICAL_CHART", "SEER_CLINICALLY_SIGNIFICANT" ]
@@ -481,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bgc",
@@ -604,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -727,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -856,8 +829,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -877,11 +849,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -896,11 +866,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -997,47 +965,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1047,82 +1001,57 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "nodes_pos_fae", "ssf25_snt", "extension_bgc", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "size_ana", "cs_input_version_original", "ssf22_snq", "lvi", "ssf14_sni", "mets_eval_ina", "ssf2_kbx", "ajcc_tdescriptor_cleanup", "ssf4_mna", "extension_eval_cna", "ajcc6_stage_qna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "schema_selection_myeloma_plasma_cell_disorder", "grade", "summary_stage_rpa", "nodes_eval_ena", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf3_lbb", "ajcc6_t_codes", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ss_codes", "ssf6_ona", "ajcc6_n_codes", "mets_hna", "behavior", "ssf10_sne", "ssf18_snm", "nodes_exam_gac", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "ssf1_jch", "cs_year_validation", "ssf24_sns", "nodes_dfy", "ssf8_snc", "ssf12_sng" ],
-  "last_modified" : "2015-08-25T18:31:32.404Z"
+  "last_modified" : "2018-08-24T15:56:30.891Z"
 }

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/nasal_cavity.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/nasal_cavity.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bcq",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upt",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -938,11 +909,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpk",
@@ -984,11 +953,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -999,8 +966,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1089,47 +1055,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1139,80 +1091,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ajcc6_exclusions_ppd", "ssf1_jpa", "schema_selection_nasal_cavity", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "mets_hpb", "ssf22_snq", "lvi", "ssf14_sni", "nodes_dcx", "ajcc_tdescriptor_cleanup", "ssf9_spc", "lymph_nodes_size_xpd", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpb", "ssf17_snl", "ajcc_descriptor_codes", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_stage_upt", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf18_snm", "mets_eval_ipa", "extension_bcq", "extension_eval_cpa", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ajcc6_stage_qpk", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/nasopharynx.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/nasopharynx.json
@@ -480,35 +480,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bas",
@@ -603,32 +595,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -726,32 +710,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -853,11 +829,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ssf25_spj",
@@ -900,8 +874,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -921,11 +894,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -944,11 +915,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ssf25_spj",
@@ -994,11 +963,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1009,8 +976,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1099,47 +1065,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1149,80 +1101,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ajcc6_exclusions_ppd", "ssf1_jpa", "lymph_nodes_size_table_csv2_xcp", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "nodes_dcn", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "mets_hpb", "ajcc7_stage_uae", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "extension_bas", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpb", "ssf17_snl", "ajcc_descriptor_codes", "lymph_nodes_size_ajcc6_table_csv1_xex", "schema_selection_nasopharynx", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf8_spb", "ssf25_spj", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ajcc6_stage_qak", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf11_snf", "ss_codes", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/net_ampulla.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/net_ampulla.json
@@ -481,35 +481,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bfo",
@@ -604,32 +596,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -727,32 +711,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -854,11 +830,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_uqa",
@@ -897,8 +871,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -918,11 +891,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -941,11 +912,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpp",
@@ -987,11 +956,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1002,8 +969,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1092,47 +1058,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1142,80 +1094,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf2_kna", "mets_hco", "ajcc6_exclusions_ppe", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "size_aar", "extension_bfo", "cs_input_version_original", "extension_size_ajcc7_xfe", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf4_mas", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "ajcc7_stage_uqa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ajcc7_inclusions_tpm", "ssf16_snk", "ssf1_jna", "ajcc6_t_codes", "ssf6_oam", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "nodes_dfk", "ssf3_lna", "ss_codes", "nodes_exam_gpa", "ajcc6_n_codes", "schema_selection_net_ampulla", "behavior", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ajcc6_stage_qpp", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ssf5_nap", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/net_colon.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/net_colon.json
@@ -480,35 +480,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bfi",
@@ -603,32 +595,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -726,32 +710,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -853,11 +829,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upx",
@@ -896,8 +870,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -917,11 +890,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -940,11 +911,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpf",
@@ -986,11 +955,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1001,8 +968,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1091,47 +1057,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1141,80 +1093,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf11_sps", "ajcc6_exclusions_ppd", "ssf25_snt", "mets_hci", "ssf15_snj", "ajcc7_t_codes", "schema_selection_net_colon", "ssf23_snr", "histology", "extension_bfi", "cs_input_version_original", "ssf22_snq", "ssf1_jpv", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf4_mna", "ajcc7_year_validation", "ssf21_snp", "ajcc_descriptor_codes", "extension_size_ajcc7_xkg", "lymph_nodes_clinical_evaluation6th_xqf", "grade", "ajcc7_stage_upx", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ajcc7_inclusions_tpm", "ssf16_spt", "nodes_dfe", "ajcc6_t_codes", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf3_lna", "ss_codes", "determine_correct_table_for_ajcc6_n_ns22", "ssf6_ona", "nodes_exam_gpa", "ssf17_spu", "ajcc6_n_codes", "behavior", "ssf2_kpi", "size_apk", "ssf10_sne", "ssf18_snm", "lymph_nodes_pathologic_evaluation6th_table_also_used_when_csreg_nodes_evalis_not_coded_xqg", "mets_eval_ipa", "ajcc6_stage_qpf", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "nodes_pos_fpc", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/net_rectum.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/net_rectum.json
@@ -480,35 +480,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bfj",
@@ -603,32 +595,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -726,32 +710,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -853,11 +829,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upx",
@@ -896,8 +870,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -917,11 +890,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -940,11 +911,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpf",
@@ -986,11 +955,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1001,8 +968,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1091,47 +1057,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1141,80 +1093,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf11_sps", "ajcc6_exclusions_ppd", "ssf25_snt", "ssf15_snj", "mets_hcj", "ajcc7_t_codes", "ssf23_snr", "histology", "extension_bfj", "schema_selection_net_rectum", "cs_input_version_original", "ssf22_snq", "ssf1_jpv", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf4_mna", "ajcc7_year_validation", "ssf21_snp", "ajcc_descriptor_codes", "lymph_nodes_clinical_evaluation6th_xqf", "extension_size_ajcc7_xkh", "grade", "ajcc7_stage_upx", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ajcc7_inclusions_tpm", "ssf16_spt", "nodes_dff", "ajcc6_t_codes", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf3_lna", "ss_codes", "determine_correct_table_for_ajcc6_n_ns22", "ssf6_ona", "nodes_exam_gpa", "ssf17_spu", "ajcc6_n_codes", "behavior", "ssf2_kpi", "size_apk", "ssf10_sne", "ssf18_snm", "lymph_nodes_pathologic_evaluation6th_table_also_used_when_csreg_nodes_evalis_not_coded_xqg", "mets_eval_ipa", "ajcc6_stage_qpf", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "nodes_pos_fpc", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/net_small_intestine.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/net_small_intestine.json
@@ -481,35 +481,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bfp",
@@ -604,32 +596,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -727,32 +711,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -854,11 +830,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_uqa",
@@ -897,8 +871,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -918,11 +891,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -941,11 +912,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpn",
@@ -987,11 +956,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1002,8 +969,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1092,47 +1058,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1142,80 +1094,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf2_kna", "mets_hcp", "ajcc6_exclusions_ppd", "schema_selection_net_small_intestine", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "size_aas", "cs_input_version_original", "extension_size_ajcc7_xff", "ssf22_snq", "ssf6_opi", "lvi", "extension_bfp", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf4_mna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "ajcc7_stage_uqa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ajcc7_inclusions_tpm", "ssf16_snk", "ssf1_jna", "nodes_dfl", "ajcc6_t_codes", "nodes_pos_fpa", "ssf11_sri", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf3_lna", "ss_codes", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ajcc6_stage_qpn", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "ssf12_srj", "cs_year_validation", "ssf24_sns", "ssf8_snc" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/net_stomach.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/net_stomach.json
@@ -481,35 +481,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bfk",
@@ -604,32 +596,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -727,32 +711,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -854,11 +830,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_uao",
@@ -897,8 +871,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -918,11 +891,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -941,11 +912,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpl",
@@ -987,11 +956,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1002,8 +969,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1092,47 +1058,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1142,80 +1094,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "mets_hck", "ssf2_kna", "ajcc6_exclusions_ppd", "ssf25_snt", "ajcc7_stage_uao", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "size_aap", "extension_bfk", "histology", "cs_input_version_original", "lymph_nodes_pathologic_evaluation6th_table_also_used_when_csreg_nodes_evalis_not_coded_xpp", "ssf22_snq", "ssf6_opi", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf4_mna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ajcc7_inclusions_tpm", "ssf16_snk", "nodes_dfg", "ajcc6_t_codes", "lymph_nodes_clinical_evaluation_ajcc6_xpo", "ssf11_sri", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf3_lna", "ss_codes", "determine_correct_table_for_ajcc6_n_ns23", "nodes_exam_gpa", "ajcc6_n_codes", "ssf1_jbg", "behavior", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "schema_selection_net_stomach", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "extension_size_ajcc7_xey", "ssf19_snn", "ajcc7_stage_codes", "ajcc6_stage_qpl", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "nodes_pos_fpc", "ajcc6_m_codes", "nodes_eval_epa", "ssf12_srj", "cs_year_validation", "ssf24_sns", "ssf8_snc" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/orbit.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/orbit.json
@@ -482,35 +482,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bag",
@@ -605,32 +597,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -728,32 +712,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -855,11 +831,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_unb",
@@ -898,8 +872,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -919,11 +892,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -942,11 +913,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qnb",
@@ -988,11 +957,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1003,8 +970,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1093,47 +1059,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1143,80 +1095,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ajcc6_exclusions_ppc", "ssf2_kna", "ssf25_snt", "ajcc7_stage_unb", "size_aaj", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "nodes_dpa", "histology", "cs_input_version_original", "mets_hpc", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "extension_size_xaf", "ssf4_mna", "ajcc6_stage_qnb", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "grade", "ajcc7_inclusions_tpp", "summary_stage_rpa", "ajcc7_m_codes", "schema_selection_orbit", "extension_bag", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf1_jna", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ssf3_lna", "ss_codes", "ssf6_ona", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "cs_year_validation", "nodes_eval_epb", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/oropharynx.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/oropharynx.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bap",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upt",
@@ -895,8 +869,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -916,11 +889,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -939,11 +910,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpk",
@@ -985,11 +954,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1000,8 +967,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1090,47 +1056,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1140,80 +1092,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "schema_selection_oropharynx", "ajcc6_exclusions_ppd", "ssf1_jpa", "extension_size_ajcc6_xaz", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "mets_hpb", "nodes_dcu", "ssf22_snq", "lvi", "ssf14_sni", "extension_bap", "ajcc_tdescriptor_cleanup", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpb", "ssf17_snl", "lymph_nodes_size_xpg", "ajcc_descriptor_codes", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_stage_upt", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "extension_size_ajcc7_xdw", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf11_snf", "ss_codes", "nodes_exam_gpa", "ajcc6_n_codes", "size_aph", "behavior", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ajcc6_stage_qpk", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/ovary.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/ovary.json
@@ -480,35 +480,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bbg",
@@ -603,32 +595,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -726,32 +710,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -853,11 +829,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_ubf",
@@ -896,8 +870,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -917,11 +890,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -940,11 +911,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qbi",
@@ -986,11 +955,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1001,8 +968,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1091,47 +1057,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1141,80 +1093,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ajcc7_inclusions_tpx", "ssf3_lpt", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "extension_bbg", "histology", "schema_selection_ovary", "cs_input_version_original", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf5_npl", "ssf2_kbu", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf1_jae", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "mets_hah", "ssf11_snf", "ss_codes", "ajcc6_exclusions_pad", "ajcc6_stage_qbi", "ssf6_ona", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "nodes_day", "behavior", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ssf4_mpr", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ajcc7_stage_ubf", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/palate_hard.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/palate_hard.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bah",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upt",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -938,11 +909,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpk",
@@ -984,11 +953,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -999,8 +966,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1089,47 +1055,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1139,80 +1091,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ajcc6_exclusions_ppd", "ssf1_jpa", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "mets_hpb", "ssf22_snq", "nodes_dpc", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "extension_size_xae", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpb", "ssf17_snl", "lymph_nodes_size_xpg", "ajcc_descriptor_codes", "ssf5_npa", "grade", "summary_stage_rpa", "extension_bah", "ajcc7_m_codes", "ajcc7_stage_upt", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "schema_selection_palate_hard", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "nodes_exam_gpa", "size_apc", "ajcc6_n_codes", "behavior", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ajcc6_stage_qpk", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/palate_soft.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/palate_soft.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_baq",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upt",
@@ -895,8 +869,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -916,11 +889,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -939,11 +910,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpk",
@@ -985,11 +954,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1000,8 +967,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1090,47 +1056,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1140,80 +1092,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ajcc6_exclusions_ppd", "ssf1_jpa", "schema_selection_palate_soft", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "extension_size_ajcc7_xfc", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "mets_hpb", "ssf22_snq", "lvi", "ssf14_sni", "extension_baq", "ajcc_tdescriptor_cleanup", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpb", "ssf17_snl", "lymph_nodes_size_xpg", "ajcc_descriptor_codes", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_stage_upt", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf11_snf", "nodes_dao", "ss_codes", "nodes_exam_gpa", "ajcc6_n_codes", "size_aph", "behavior", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ajcc6_stage_qpk", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "extension_size_ajcc6_xav", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/pancreas_body_tail.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/pancreas_body_tail.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bdf",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_ups",
@@ -895,8 +869,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -916,11 +889,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -939,11 +910,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qas",
@@ -985,11 +954,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1000,8 +967,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1090,47 +1056,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1140,80 +1092,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ajcc6_exclusions_ppb", "ssf25_snt", "ssf1_jpe", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf3_lpd", "histology", "cs_input_version_original", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf4_mna", "ajcc6_stage_qas", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_stage_ups", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpd", "mets_hap", "lymph_nodes_metsat_dxajcc6_xje", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ss_codes", "extension_size_xpe", "ssf6_ona", "nodes_exam_gpa", "extension_bdf", "ajcc6_n_codes", "size_apg", "schema_selection_pancreas_body_tail", "behavior", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc7_inclusions_tae", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "nodes_dbm", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/pancreas_head.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/pancreas_head.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bbv",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_ups",
@@ -895,8 +869,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -916,11 +889,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -939,11 +910,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qat",
@@ -985,11 +954,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1000,8 +967,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1090,47 +1056,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1140,80 +1092,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ajcc6_exclusions_ppb", "extension_bbv", "ssf25_snt", "ssf1_jpe", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf3_lpd", "histology", "cs_input_version_original", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf4_mna", "ajcc6_stage_qat", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "grade", "schema_selection_pancreas_head", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_stage_ups", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpd", "ajcc6_t_codes", "nodes_pos_fpa", "lymph_nodes_metsat_dxajcc6_xjf", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ss_codes", "extension_size_xpe", "ssf6_ona", "nodes_exam_gpa", "mets_haq", "ajcc6_n_codes", "size_apg", "behavior", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc7_inclusions_tae", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "nodes_dbn", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/pancreas_other.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/pancreas_other.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bbu",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_ups",
@@ -895,8 +869,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -916,11 +889,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -939,11 +910,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qar",
@@ -985,11 +954,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1000,8 +967,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1090,47 +1056,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1140,80 +1092,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "schema_selection_pancreas_other", "ajcc6_exclusions_ppb", "extension_bbu", "ssf25_snt", "ssf1_jpe", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf3_lpd", "histology", "cs_input_version_original", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf4_mna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "grade", "ajcc6_stage_qar", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_stage_ups", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpd", "mets_hao", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ss_codes", "extension_size_xpe", "ssf6_ona", "nodes_exam_gpa", "ajcc6_n_codes", "size_apg", "behavior", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc7_inclusions_tae", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "nodes_dbl", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/parotid_gland.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/parotid_gland.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bcv",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_uqc",
@@ -895,8 +869,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -916,11 +889,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -939,11 +910,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpr",
@@ -985,11 +954,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1000,8 +967,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1090,47 +1056,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1140,80 +1092,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ajcc6_exclusions_ppd", "ssf1_jpa", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "ssf6_opa", "ssf3_lpa", "ajcc6_stage_qpr", "cs_input_version_original", "mets_hpb", "ssf22_snq", "nodes_dcv", "lvi", "ajcc7_inclusions_tqn", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_stage_uqc", "schema_selection_parotid_gland", "ssf17_snl", "lymph_nodes_size_xpg", "ajcc_descriptor_codes", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "extension_size_xpf", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf11_snf", "ss_codes", "nodes_exam_gpa", "ajcc6_n_codes", "size_aph", "behavior", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "extension_bcv", "ssf4_mpa", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/penis.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/penis.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bbs",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_uav",
@@ -895,8 +869,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -916,11 +889,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -939,11 +910,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qps",
@@ -985,11 +954,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1000,8 +967,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1090,47 +1056,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1140,80 +1092,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "extension_bbs", "ssf2_kna", "ajcc7_stage_uav", "ajcc6_exclusions_ppd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "ajcc6_stage_qps", "cs_input_version_original", "ssf22_snq", "mets_hpe", "lvi", "ssf14_sni", "ssf17_seu", "ajcc_tdescriptor_cleanup", "ssf4_mna", "ssf16_sqv", "ajcc7_year_validation", "ssf21_snp", "extension_grade_lvi_xdm", "ajcc_descriptor_codes", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_inclusions_tpq", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf1_jna", "ajcc6_t_codes", "ssf10_seq", "nodes_dbj", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf3_lna", "ss_codes", "ssf6_ona", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "ssf11_ser", "behavior", "lymph_node_extranodal_extension_xdn", "ssf18_snm", "mets_eval_ipa", "ssf12_ses", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "schema_selection_penis", "cs_year_validation", "ssf24_sns", "ssf8_snc" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/peritoneum.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/peritoneum.json
@@ -480,35 +480,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bbr",
@@ -603,32 +595,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -726,32 +710,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -853,11 +829,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ssf25_sqp",
@@ -904,8 +878,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -925,11 +898,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -948,11 +919,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ssf25_sqp",
@@ -998,11 +967,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1013,8 +980,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1103,47 +1069,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1153,80 +1105,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "extension_bbr", "ajcc6_exclusions_ppc", "ajcc7_inclusions_tpz", "ssf3_lpk", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf1_jpm", "histology", "cs_input_version_original", "mets_hpc", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "extension_size_xqj", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_stage_upm", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "schema_selection_peritoneum", "ajcc6_t_codes", "nodes_dbi", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ss_codes", "ssf6_ona", "nodes_exam_gpa", "ssf25_sqp", "ajcc6_n_codes", "ssf2_kpk", "behavior", "ssf10_sne", "ssf18_snm", "ajcc6_stage_qpi", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "size_apu", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "ssf4_mpf", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/peritoneum_female_gen.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/peritoneum_female_gen.json
@@ -481,35 +481,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bfx",
@@ -604,32 +596,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -727,32 +711,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -854,11 +830,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ssf25_sqp",
@@ -901,8 +875,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -922,11 +895,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -945,11 +916,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ssf25_sqp",
@@ -995,11 +964,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1010,8 +977,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1100,47 +1066,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1150,80 +1102,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ajcc6_exclusions_ppc", "ssf3_lpt", "extension_bfx", "ajcc7_inclusions_tqa", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "cs_input_version_original", "ssf1_jpr", "mets_hcw", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf5_npl", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ss_codes", "ssf6_ona", "nodes_exam_gpa", "ssf25_sqp", "ajcc6_n_codes", "ssf2_kpn", "extension_size_xgn", "behavior", "ssf10_sne", "ssf18_snm", "ajcc6_stage_qpi", "mets_eval_ipa", "size_app", "extension_eval_cpa", "ajcc7_n_codes", "ajcc7_stage_uby", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "schema_selection_peritoneum_female_gen", "ssf4_mpr", "nodes_dfs", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/pharyngeal_tonsil.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/pharyngeal_tonsil.json
@@ -480,35 +480,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bey",
@@ -603,32 +595,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -726,32 +710,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -853,11 +829,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ssf25_spj",
@@ -900,8 +874,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -921,11 +894,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -944,11 +915,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ssf25_spj",
@@ -994,11 +963,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1009,8 +976,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1099,47 +1065,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1149,80 +1101,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "lymph_nodes_size_csv1_xix", "ssf10_spd", "ajcc6_exclusions_ppd", "ssf1_jpa", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "mets_hpb", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "extension_bey", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpb", "ssf17_snl", "ajcc_descriptor_codes", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_stage_upt", "ssf8_spb", "ssf25_spj", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "schema_selection_pharyngeal_tonsil", "extension_size_ajcc7_xdl", "ssf2_kpa", "ajcc6_t_codes", "extension_size_ajcc6_xdk", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf11_snf", "ss_codes", "nodes_det", "nodes_exam_gpa", "ajcc6_n_codes", "size_aph", "behavior", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "ajcc6_stage_qpb", "ssf19_snn", "ajcc7_stage_codes", "ssf13_snh", "primary_site", "ajcc6_year_validation", "lymph_nodes_size_csv2_xiw", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/pharynx_other.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/pharynx_other.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bdd",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -854,8 +830,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -875,11 +850,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -898,11 +871,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -944,11 +915,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -959,8 +928,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1049,47 +1017,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1099,80 +1053,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ajcc6_exclusions_ppd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "ssf6_opa", "ssf3_lpa", "nodes_dcy", "cs_input_version_original", "ssf1_jpu", "ssf22_snq", "lvi", "mets_hpf", "ssf14_sni", "mets_eval_ina", "ajcc_tdescriptor_cleanup", "extension_eval_cna", "ajcc6_stage_qna", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "ssf5_npa", "grade", "summary_stage_rpa", "nodes_eval_ena", "ajcc7_m_codes", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "schema_selection_pharynx_other", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf11_snf", "ss_codes", "extension_bdd", "nodes_exam_gpa", "size_apd", "ajcc6_n_codes", "behavior", "ssf18_snm", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "ssf19_snn", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/placenta.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/placenta.json
@@ -482,35 +482,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bbm",
@@ -605,32 +597,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -728,32 +712,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -855,11 +831,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_uax",
@@ -898,8 +872,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -919,11 +892,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -942,11 +913,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qau",
@@ -988,11 +957,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1003,8 +970,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1093,47 +1059,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1143,80 +1095,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf2_kaw", "ajcc7_stage_uax", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "cs_input_version_original", "nodes_exam_gna", "ssf22_snq", "extension_bbm", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf4_mna", "ajcc6_stage_qau", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "ajcc7_inclusions_tpi", "nodes_pos_fna", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "mets_hak", "ssf1_jaq", "ajcc6_t_codes", "nodes_eval_eaa", "nodes_dfm", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ssf3_lna", "ss_codes", "schema_selection_placenta", "ssf6_ona", "size_apa", "ajcc6_exclusions_paf", "ajcc6_n_codes", "behavior", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/pleura.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/pleura.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bbx",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_uaq",
@@ -895,8 +869,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -916,11 +889,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -939,11 +910,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qam",
@@ -985,11 +954,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1000,8 +967,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1090,47 +1056,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1140,80 +1092,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf25_snt", "extension_bbx", "ssf15_snj", "ajcc7_t_codes", "ajcc7_stage_uaq", "schema_selection_pleura", "ssf23_snr", "ssf2_kbf", "histology", "cs_input_version_original", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "pleural_effusion_extension_xbz", "lymph_nodes_metsat_dxajcc6_xki", "grade", "ajcc7_inclusions_tpf", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc6_stage_qam", "ssf4_maz", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf1_jam", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ajcc6_exclusions_pam", "ssf7_snb", "ssf11_snf", "ssf3_lat", "ss_codes", "ssf6_ona", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "mets_hat", "behavior", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ssf5_naw", "ssf9_snd", "ssf13_snh", "primary_site", "nodes_dbq", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/prostate.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/prostate.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "determine_correct_table_for_t_ns28",
@@ -585,32 +577,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -708,32 +692,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -835,11 +811,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_ubp",
@@ -878,8 +852,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -899,11 +872,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -922,11 +893,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qaj",
@@ -968,11 +937,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -983,8 +950,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1073,47 +1039,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1123,80 +1075,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ajcc7_inclusions_tpv", "ssf25_snt", "ajcc7_t_codes", "ssf23_snr", "extension_eval_6_cab", "schema_selection_prostate", "histology", "special_calculation_non_invasive_pathologic_extension_xdr_xdt_xdq", "ssf14_sbd", "cs_input_version_original", "extension_sstg_bbo", "extension_bbo", "ssf22_snq", "lvi", "ssf3_sstg_lab", "ajcc_tdescriptor_cleanup", "ssf3_lab", "ajcc7_year_validation", "ssf21_snp", "ssf4_maf", "ssf17_snl", "ajcc_descriptor_codes", "special_calculation_invasive_unknown_pathologic_extension_xds_xdu_xdq", "ajcc6_stage_qaj", "extension_eval_cab", "ssf15_sbe", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ajcc6_stage_qaj_grade", "mets_hal", "ssf6_oad", "ssf11_sba", "ajcc6_t_codes", "ssf1_jav", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_saw", "nodes_dbf", "ss_codes", "size_apa", "nodes_exam_gpa", "ajcc6_exclusions_pag", "ajcc6_n_codes", "behavior", "ssf10_saz", "mets_eval_ipb", "ssf18_snm", "ssf13_sbc", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ssf9_say", "ajcc7_stage_ubp", "ssf12_sbb", "primary_site", "ajcc6_year_validation", "ssf2_kab", "determine_correct_table_for_t_ns28", "ajcc6_m_codes", "nodes_eval_epa", "ssf8_sax", "cs_year_validation", "ssf5_nae", "ssf24_sns" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/rectum.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/rectum.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bbf",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upw",
@@ -895,8 +869,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -916,11 +889,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -939,11 +910,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpf",
@@ -985,11 +954,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1000,8 +967,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1090,47 +1056,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1140,80 +1092,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ajcc6_exclusions_ppd", "size_aae", "ssf25_snt", "ssf7_spf", "ssf1_jpf", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf3_lpe", "histology", "extension_bbf", "ssf6_opb", "cs_input_version_original", "ssf22_snq", "ssf10_spi", "lvi", "ssf14_sni", "lymph_nodes_pathologic_evaluation_ajcc7_table_also_used_when_cslymph_nodes_evalis_not_coded_xqi", "ajcc_tdescriptor_cleanup", "schema_selection_rectum", "ajcc7_year_validation", "ssf21_snp", "ssf5_npb", "ssf17_snl", "ssf9_sph", "ajcc_descriptor_codes", "lymph_nodes_clinical_evaluation_ajcc6_xbi", "ajcc7_inclusions_tpc", "ajcc7_stage_upw", "grade", "ssf8_spg", "summary_stage_rpa", "ajcc7_m_codes", "lymph_nodes_pathologic_evaluation_ajcc6_table_also_used_when_cslymph_nodes_eval_is_not_coded_xpr", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ajcc6_t_codes", "nodes_pos_fpb", "ajcc_mdescriptor_cleanup", "mets_hag", "ssf11_snf", "determine_correct_table_for_ajcc6_n_ns24", "ss_codes", "determine_correct_table_for_ajcc7_n_ns25", "nodes_exam_gpa", "ssf2_kpp", "ajcc6_n_codes", "nodes_dax", "behavior", "mets_eval_ipb", "ssf18_snm", "ajcc6_stage_qpf", "extension_eval_cpa", "ajcc7_n_codes", "ssf4_mpb", "ajcc6_stage_codes", "ssf19_snn", "lymph_nodes_clinical_eval_priorto_v0205_ajcc7_xqh", "ajcc7_stage_codes", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "lymph_nodes_clinical_eval_v0205_ajcc7_xch", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/respiratory_other.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/respiratory_other.json
@@ -482,35 +482,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bce",
@@ -605,32 +597,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -728,32 +712,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -857,8 +833,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -878,11 +853,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -897,11 +870,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -998,47 +969,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1048,80 +1005,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf2_kna", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "cs_input_version_original", "mets_hpa", "ssf22_snq", "lvi", "ssf14_sni", "mets_eval_ina", "ajcc_tdescriptor_cleanup", "ssf4_mna", "extension_eval_cna", "ajcc6_stage_qna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "grade", "summary_stage_rpa", "nodes_eval_ena", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf1_jna", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ssf3_lna", "ss_codes", "ssf6_ona", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf10_sne", "ssf18_snm", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "extension_bce", "ajcc6_m_codes", "cs_year_validation", "ssf24_sns", "nodes_dbv", "schema_selection_respiratory_other", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/retinoblastoma.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/retinoblastoma.json
@@ -477,35 +477,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "special_calculation_tablefor_ajcct_xiu",
@@ -588,32 +580,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -711,32 +695,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -838,11 +814,9 @@
       "inputs" : [ "site", "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_unb",
@@ -881,8 +855,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -902,11 +875,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -921,11 +892,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qnb",
@@ -1022,47 +991,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1072,80 +1027,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "metsat_dxmets_eval_ajcc7_xfg", "determine_correct_table_for_ajcc6_meval_ns30", "ssf25_snt", "ajcc7_stage_unb", "ssf15_snj", "ajcc7_t_codes", "extension_eval_6_cac", "ssf23_snr", "histology", "ssf2_kbb", "cs_input_version_original", "ssf22_snq", "lvi", "ssf14_sni", "ssf1_sstg_jat", "lymph_nodes_metsat_dxajcc6_xfh_n", "ajcc_tdescriptor_cleanup", "lymph_nodes_metsat_dxajcc6_xfh_m", "ssf4_mat", "mets_hbn", "ajcc6_stage_qnb", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "extension_sstg_bcu", "extension_eval_cac", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_inclusions_tpk", "schema_selection_retinoblastoma", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf1_jat", "ajcc6_t_codes", "ssf6_oao", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ss_codes", "determine_correct_table_for_ajcc6_neval_ns31", "size_apa", "nodes_exam_gpa", "ssf3_lao", "special_calculation_tablefor_ajcct_xiu", "ajcc6_n_codes", "behavior", "metsat_dxmets_eval_ajcc6_xck", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "ajcc7_n_codes", "ajcc6_stage_codes", "extension_bcu", "nodes_dcj", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "determine_correct_table_for_ajcc6_m_ns29", "ssf5_naq", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "special_calculation_tablefor_seersummary_stage_xiv", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/retroperitoneum.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/retroperitoneum.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bfv",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ssf1_jpm",
@@ -899,8 +873,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -920,11 +893,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -943,11 +914,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpi",
@@ -989,11 +958,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1004,8 +971,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1094,47 +1060,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1144,80 +1096,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "extension_bfv", "ajcc6_exclusions_ppc", "ssf3_lpk", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf1_jpm", "histology", "cs_input_version_original", "ajcc7_inclusions_tab", "mets_hpc", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "extension_size_xqj", "ajcc7_year_validation", "ssf21_snp", "schema_selection_retroperitoneum", "ssf17_snl", "ajcc_descriptor_codes", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_stage_upm", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ss_codes", "ssf6_ona", "nodes_exam_gpa", "ajcc6_n_codes", "ssf2_kpk", "behavior", "ssf10_sne", "ssf18_snm", "ajcc6_stage_qpi", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "size_apu", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "nodes_dfq", "ajcc6_m_codes", "nodes_eval_epa", "ssf4_mpf", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/salivary_gland_other.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/salivary_gland_other.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bba",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_uqc",
@@ -895,8 +869,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -916,11 +889,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -939,11 +910,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpr",
@@ -985,11 +954,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1000,8 +967,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1090,47 +1056,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1140,80 +1092,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ajcc6_exclusions_ppd", "ssf1_jpa", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "extension_bba", "histology", "ssf6_opa", "ssf3_lpa", "ajcc6_stage_qpr", "cs_input_version_original", "mets_hpb", "ssf22_snq", "lvi", "ajcc7_inclusions_tqn", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf9_spc", "lymph_nodes_size_xpd", "ajcc7_year_validation", "ssf21_snp", "ajcc7_stage_uqc", "ssf17_snl", "ajcc_descriptor_codes", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "extension_size_xpf", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf11_snf", "ss_codes", "nodes_exam_gpa", "schema_selection_salivary_gland_other", "ajcc6_n_codes", "size_aph", "behavior", "nodes_das", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/scrotum.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/scrotum.json
@@ -480,35 +480,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bdo",
@@ -603,32 +595,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -726,32 +710,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -853,11 +829,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_uay",
@@ -896,8 +870,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -917,11 +890,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -940,11 +911,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpt",
@@ -986,11 +955,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1001,8 +968,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1091,47 +1057,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1141,80 +1093,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf2_kna", "ajcc6_exclusions_ppd", "ajcc7_stage_uay", "nodes_ddj", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "ajcc6_stage_qpt", "ssf1_jpp", "cs_input_version_original", "ssf22_snq", "mets_hpe", "lvi", "ssf14_sni", "ssf16_squ", "ssf11_sqt", "ajcc_tdescriptor_cleanup", "ssf4_mna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "ssf10_sqs", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_inclusions_tpq", "ssf20_sno", "schema_selection_scrotum", "ajcc_ndescriptor_cleanup", "ajcc6_t_codes", "lymph_nodes_size_ajcc7_xfb", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf3_lna", "ss_codes", "extension_size_high_risk_xfa", "ssf6_ona", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "extension_bdo", "extension_size_ajcc6_xqb", "size_apl", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf12_sev", "ssf5_nna", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf8_snc" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/sinus_ethmoid.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/sinus_ethmoid.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bay",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upt",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -938,11 +909,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpk",
@@ -984,11 +953,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -999,8 +966,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1089,47 +1055,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1139,80 +1091,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ajcc6_exclusions_ppd", "ssf1_jpa", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "nodes_dcm", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "mets_hpb", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf9_spc", "lymph_nodes_size_xpd", "ajcc7_year_validation", "extension_bay", "ssf21_snp", "ajcc7_inclusions_tpb", "ssf17_snl", "ajcc_descriptor_codes", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_stage_upt", "ssf8_spb", "ssf20_sno", "schema_selection_sinus_ethmoid", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ajcc6_stage_qpk", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/sinus_maxillary.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/sinus_maxillary.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bax",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upt",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -938,11 +909,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpk",
@@ -984,11 +953,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -999,8 +966,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1089,47 +1055,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1139,80 +1091,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ajcc6_exclusions_ppd", "schema_selection_sinus_maxillary", "ssf1_jpa", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "mets_hpb", "ssf22_snq", "lvi", "nodes_dcw", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf9_spc", "lymph_nodes_size_xpd", "ajcc7_year_validation", "ssf21_snp", "extension_bax", "ajcc7_inclusions_tpb", "ssf17_snl", "ajcc_descriptor_codes", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_stage_upt", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ajcc6_stage_qpk", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/sinus_other.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/sinus_other.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bdk",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -853,8 +829,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -874,11 +849,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -893,11 +866,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -994,47 +965,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1044,80 +1001,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "ssf1_jpu", "ssf22_snq", "lvi", "mets_hpf", "ssf14_sni", "mets_eval_ina", "ajcc_tdescriptor_cleanup", "extension_eval_cna", "ajcc6_stage_qna", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "ssf5_npa", "grade", "summary_stage_rpa", "nodes_eval_ena", "ajcc7_m_codes", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "nodes_daq", "size_apa", "nodes_exam_gpa", "schema_selection_sinus_other", "ajcc6_n_codes", "extension_bdk", "behavior", "ssf18_snm", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "ssf19_snn", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/skin.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/skin.json
@@ -481,35 +481,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bca",
@@ -604,32 +596,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -727,32 +711,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -854,11 +830,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_ubg",
@@ -897,8 +871,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -918,11 +891,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -941,11 +912,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qav",
@@ -987,11 +956,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1002,8 +969,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1092,47 +1058,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1142,80 +1094,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf2_kna", "ajcc6_exclusions_ppd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "ssf1_jpp", "cs_input_version_original", "ssf22_snq", "mets_hpe", "lvi", "extension_size_ajcc6_xfw", "ssf14_sni", "ssf16_squ", "ssf11_sqt", "lymph_nodes_size_ajcc7_xfz", "ajcc_tdescriptor_cleanup", "ssf4_mna", "ajcc6_stage_qav", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "ssf10_sqs", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_inclusions_tpq", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ajcc6_t_codes", "extension_size_high_risk_xfy", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf3_lna", "ss_codes", "ssf6_ona", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "size_apl", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ssf12_sew", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "extension_bca", "ajcc7_stage_ubg", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "schema_selection_skin", "nodes_dbt", "ssf24_sns", "ssf8_snc" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/skin_eyelid.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/skin_eyelid.json
@@ -470,35 +470,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bdg",
@@ -593,32 +585,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -716,32 +700,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -843,11 +819,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_uaf",
@@ -886,8 +860,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -907,11 +880,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -930,11 +901,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qnb",
@@ -976,11 +945,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -991,8 +958,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1081,47 +1047,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1131,80 +1083,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf8_sdd", "nodes_dde", "ssf7_scq", "ssf25_snt", "ssf4_mbg", "extension_size_perineural_invasion_positive_ajcc6_table_csv2_xgm", "extension_size_ajcc6_table_csv1_xjb", "ssf10_scm", "determine_correct_table_for_ajcc6_t_ns39", "ajcc7_t_codes", "ssf23_snr", "histology", "ajcc7_stage_uaf", "extension_size_perineural_invasion888988_ajcc7_xic", "cs_input_version_original", "mets_hcu", "ssf11_scj", "ssf22_snq", "ssf9_sdi", "ssf2_kaz", "lvi", "ajcc_tdescriptor_cleanup", "ajcc6_stage_qnb", "ssf12_sck", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpb", "ssf17_snl", "ajcc_descriptor_codes", "determine_correct_table_for_ajcc7_t_ns38", "extension_size_perineural_invasion888988_ajcc6_table_csv2_xij", "grade", "extension_size_perineural_invasion_positive_ajcc7_xgk", "summary_stage_rpa", "ajcc7_m_codes", "ssf13_scl", "ssf20_sno", "ajcc_ndescriptor_cleanup", "extension_size_perineural_invasion_negativeor_unknown_ajcc6_table_csv2_xgl", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf6_oak", "ssf14_scn", "ajcc6_exclusions_pab", "ss_codes", "ssf3_lap", "nodes_exam_gpa", "extension_bdg", "ajcc6_n_codes", "behavior", "schema_selection_skin_eyelid", "extension_size_perineural_invasion_negativeor_unknown_ajcc7_xgj", "ssf15_sco", "ssf18_snm", "ssf1_jbl", "mets_eval_ipa", "size_app", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ssf16_scp", "primary_site", "ajcc6_year_validation", "ssf5_nar", "ajcc6_m_codes", "cs_year_validation", "nodes_eval_epb", "ssf24_sns" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/small_intestine.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/small_intestine.json
@@ -480,35 +480,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bbe",
@@ -603,32 +595,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -726,32 +710,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -853,11 +829,9 @@
       "inputs" : [ "site", "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_ual",
@@ -896,8 +870,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -917,11 +890,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -940,11 +911,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpn",
@@ -986,11 +955,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1001,8 +968,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1091,47 +1057,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1141,80 +1093,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "lymph_nodes_clinical_eval_v0205_ajcc7_xao", "ajcc6_exclusions_ppd", "ssf4_mbi", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf3_lpe", "ajcc7_stage_ual", "ajcc7_inclusions_tqk", "histology", "schema_selection_small_intestine", "lymph_nodes_pathologic_evaluation_ajcc7_table_also_used_when_cslymph_nodes_evalis_not_coded_xeg", "extension_bbe", "cs_input_version_original", "ssf22_snq", "lvi", "ssf14_sni", "ssf2_kbw", "ajcc_tdescriptor_cleanup", "mets_hbo", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "lymph_nodes_pathologic_evaluation_ajcc7_table_also_used_when_cslymph_nodes_eval_is_not_coded_xdg", "determine_correct_table_for_ajcc7_n_ns5", "ajcc6_t_codes", "nodes_pos_fpb", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ss_codes", "ssf6_ona", "size_apa", "nodes_exam_gpa", "nodes_daw", "ajcc6_n_codes", "behavior", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nbb", "ajcc6_stage_qpn", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf1_jcg", "lymph_nodes_clinical_eval_priorto_v0205_ajcc7_xdf", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/soft_tissue.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/soft_tissue.json
@@ -480,35 +480,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bbz",
@@ -603,32 +595,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -726,32 +710,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -853,11 +829,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ssf1_jpm",
@@ -900,8 +874,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -921,11 +894,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -944,11 +915,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qbv",
@@ -990,11 +959,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1005,8 +972,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1095,47 +1061,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1145,80 +1097,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ajcc6_exclusions_ppc", "ajcc7_inclusions_tps", "ssf3_lpk", "extension_bbz", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf1_jpm", "histology", "size_aat", "cs_input_version_original", "mets_hpc", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ajcc6_stage_qbv", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ss_codes", "schema_selection_soft_tissue", "ssf6_ona", "nodes_exam_gpa", "ajcc6_n_codes", "ssf2_kpk", "behavior", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "nodes_dbs", "ajcc6_m_codes", "ajcc7_stage_ubj", "nodes_eval_epa", "extension_size_xfn", "ssf4_mpf", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/stomach.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/stomach.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bal",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ssf25_spv",
@@ -899,8 +873,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -920,11 +893,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -943,11 +914,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ssf25_spv",
@@ -993,11 +962,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1008,8 +975,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1098,47 +1064,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1148,80 +1100,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "lymph_nodes_clinical_eval_v0205_ajcc7_xam", "ajcc6_exclusions_ppd", "size_aah", "ssf2_kal", "lymph_nodes_clinical_evaluation_ajcc6_xbe", "ajcc7_t_codes", "ssf23_snr", "ajcc7_inclusions_tqj", "ssf13_sdr", "ajcc7_stage_uam", "histology", "cs_input_version_original", "lymph_nodes_pathologic_evaluation6th_table_also_used_when_csreg_nodes_evalis_not_coded_xpp", "ssf22_snq", "lvi", "ajcc_tdescriptor_cleanup", "ssf4_mna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "extension_bal", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ajcc6_t_codes", "ssf25_spv", "nodes_pos_fpb", "mets_hac", "ssf1_jax", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ssf3_lna", "ss_codes", "ssf6_ona", "nodes_dak", "nodes_exam_gpa", "determine_correct_table_for_ajcc6_n_ns26", "determine_correct_table_for_ajcc7_n_ns27", "ajcc6_n_codes", "behavior", "schema_selection_stomach", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ssf14_sds", "ssf19_snn", "ajcc7_stage_codes", "ajcc6_stage_qpl", "ssf9_snd", "primary_site", "ajcc6_year_validation", "lymph_nodes_pathologic_evaluation_ajcc7_table_also_used_when_csreg_nodes_evalis_not_coded_xdi", "ajcc6_m_codes", "nodes_eval_epa", "lymph_nodes_clinical_eval_priorto_v0205_ajcc7_xdh", "cs_year_validation", "ssf15_sdt", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/submandibular_gland.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/submandibular_gland.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_baz",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_uqc",
@@ -895,8 +869,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -916,11 +889,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -939,11 +910,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpr",
@@ -985,11 +954,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1000,8 +967,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1090,47 +1056,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1140,80 +1092,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ajcc6_exclusions_ppd", "ssf1_jpa", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "schema_selection_submandibular_gland", "ssf23_snr", "histology", "ssf6_opa", "ssf3_lpa", "ajcc6_stage_qpr", "cs_input_version_original", "mets_hpb", "ssf22_snq", "lvi", "ajcc7_inclusions_tqn", "ssf14_sni", "ajcc_tdescriptor_cleanup", "extension_baz", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_stage_uqc", "ssf17_snl", "lymph_nodes_size_xpg", "ajcc_descriptor_codes", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "extension_size_xpf", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf11_snf", "ss_codes", "nodes_dar", "nodes_exam_gpa", "ajcc6_n_codes", "size_aph", "behavior", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/testis.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/testis.json
@@ -476,35 +476,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bdh",
@@ -599,32 +591,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -722,32 +706,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -849,11 +825,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "postorchiectomy_serum_tumor_marker_svalue_table_basedon_ssf131516_xgr",
@@ -904,8 +878,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -925,11 +898,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -948,11 +919,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "postorchiectomy_serum_tumor_marker_svalue_table_basedon_ssf131516_xgr",
@@ -1006,11 +975,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1021,8 +988,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1111,47 +1077,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1161,80 +1113,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf16_sfh", "extension_orchiectomy_lviajcc6_table_csv2_xis", "ssf5_nab", "ssf25_snt", "ssf15_sfg", "nodes_ddf", "ajcc7_t_codes", "ssf23_snr", "determine_correct_table_for_ajcc6_t_ns34", "histology", "schema_selection_testis", "cs_input_version_original", "ssf14_sff", "ssf22_snq", "lvi", "ssf3_lad", "ajcc_tdescriptor_cleanup", "mets_hbb", "lymph_nodes_pathologic_eval_xgu", "determine_correct_table_for_s_ns36", "combined_serum_tumor_marker_svalue_tablefor_yearof_diagnosis_less_than2010_xiz", "ajcc7_year_validation", "ssf21_snp", "ajcc7_stage_uqd", "ssf17_snl", "determine_correct_table_for_n_ns35", "ajcc_descriptor_codes", "ssf10_sek", "ajcc7_inclusions_tpj", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf1_jal", "extension_orchiectomy_lviajcc7_xgs", "ajcc6_t_codes", "ajcc6_exclusions_paj", "extension_orchiectomy_lviajcc6_table_csv1_xbv", "ajcc_mdescriptor_cleanup", "ss_codes", "size_apa", "nodes_exam_gpa", "extension_bdh", "ssf4_mac", "ajcc6_n_codes", "combined_serum_tumor_marker_svalue_tablefor_yearof_diagnosis_greater_than2009_xiy", "behavior", "ssf11_sel", "ssf7_seh", "mets_eval_ipb", "ssf6_oay", "ssf18_snm", "lymph_nodes_clinical_eval_xgt", "ssf13_sfe", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ajcc6_stage_qpq", "serum_tumor_marker_svalue_table_basedon_csssf123_xcj", "ssf19_snn", "ajcc7_stage_codes", "ssf8_sei", "determine_correct_table_for_ajcc6_stg_ns37", "primary_site", "ajcc6_year_validation", "ssf12_sfd", "ssf2_kad", "nodes_pos_fpc", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "lymph_nodes_positive_eval_blank_xgv", "ajcctnm6_stage_csv1_xpz", "ssf24_sns", "ssf9_sej", "postorchiectomy_serum_tumor_marker_svalue_table_basedon_ssf131516_xgr" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/thyroid.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/thyroid.json
@@ -482,35 +482,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bby",
@@ -605,32 +597,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -728,32 +712,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -855,11 +831,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "histologies_grade_stage_xce",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -938,11 +909,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "histologies_grade_stage_xce_6",
@@ -980,11 +949,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -995,8 +962,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1085,47 +1051,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1135,80 +1087,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf2_kna", "ajcc6_exclusions_ppd", "histology_grade_extension_ajcc6_xkw", "ssf25_snt", "extension_bby", "ajcctnm7_stage_thyroid_papillaryand_follicular_age45and_older_xdx", "extension_size_ajcc6_xbc", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ajcctnm6_stage_thyroid_anaplastic_xcg", "histology", "determine_correct_table_for_ajcc6_t_ns33", "ajcc7_stage_uag", "cs_input_version_original", "histologies_grade_stage_xce", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ajcc6_stage_qax", "ssf4_mna", "ajcctnm7_stage_thyroid_medullary_xdy", "determine_correct_table_for_ajcc7_t_ns32", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpb", "mets_hbf", "ssf17_snl", "ajcc_descriptor_codes", "determine_validity_for_ajcc7_ns42", "histologies_grade_stage_xce_6", "extension_size_ssf1_ajcc7_xgb", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ajcctnm6_stage_thyroid_papillaryand_follicular_age45and_older_xco", "ssf1_jap", "ajcc6_t_codes", "ajcctnm6_stage_thyroid_medullary_xcf", "ajcctnm7_stage_thyroid_anaplastic_xdz", "schema_selection_thyroid", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ssf3_lna", "ss_codes", "ssf6_ona", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "size_apj", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "histology_grade_extension_summary_stage_xgx", "histology_grade_extension_ssf1_ajcc7_xkv", "extension_eval_cpa", "ajcc7_n_codes", "determine_validity_for_ajcc6_ns50", "ajcc6_stage_codes", "ssf5_nna", "extension_t4_ssf1_ajcc7_xgw", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "nodes_dbr", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/tongue_anterior.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/tongue_anterior.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bac",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upt",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -938,11 +909,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpk",
@@ -984,11 +953,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -999,8 +966,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1089,47 +1055,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1139,80 +1091,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ajcc6_exclusions_ppd", "ssf1_jpa", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "ssf11_spe", "histology", "ssf6_opa", "ssf3_lpa", "cs_input_version_original", "mets_hpb", "ssf22_snq", "lvi", "nodes_dpd", "ssf14_sni", "extension_size_xab", "ajcc_tdescriptor_cleanup", "ssf9_spc", "lymph_nodes_size_xpd", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpb", "ssf17_snl", "ajcc_descriptor_codes", "ssf5_npa", "extension_bac", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_stage_upt", "ssf8_spb", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ss_codes", "nodes_exam_gpa", "size_apc", "ajcc6_n_codes", "behavior", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "schema_selection_tongue_anterior", "ajcc6_stage_qpk", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/tongue_base.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/tongue_base.json
@@ -479,35 +479,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bam",
@@ -602,32 +594,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -725,32 +709,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -852,11 +828,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_upt",
@@ -895,8 +869,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -916,11 +889,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -939,11 +910,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpk",
@@ -985,11 +954,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1000,8 +967,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1090,47 +1056,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1140,80 +1092,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf7_spa", "ssf10_spd", "ajcc6_exclusions_ppd", "ssf1_jpa", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "ssf6_opa", "ssf3_lpa", "schema_selection_tongue_base", "cs_input_version_original", "mets_hpb", "ssf22_snq", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ssf9_spc", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpb", "ssf17_snl", "lymph_nodes_size_xpg", "ajcc_descriptor_codes", "ssf5_npa", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_stage_upt", "ssf8_spb", "extension_bam", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf2_kpa", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf11_snf", "ss_codes", "nodes_exam_gpa", "nodes_dal", "ajcc6_n_codes", "size_aph", "behavior", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ssf4_mpa", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "extension_size_ajcc7_xeu", "ajcc6_stage_qpk", "ssf13_snh", "primary_site", "ajcc6_year_validation", "extension_size_ajcc6_xai", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/trachea.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/trachea.json
@@ -482,35 +482,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bcf",
@@ -605,32 +597,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -728,32 +712,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -857,8 +833,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -878,11 +853,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -897,11 +870,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -998,47 +969,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1048,80 +1005,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf2_kna", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "cs_input_version_original", "mets_hpa", "ssf22_snq", "lvi", "ssf14_sni", "mets_eval_ina", "ajcc_tdescriptor_cleanup", "ssf4_mna", "extension_eval_cna", "ajcc6_stage_qna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "schema_selection_trachea", "grade", "summary_stage_rpa", "nodes_eval_ena", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf1_jna", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ssf3_lna", "ss_codes", "ssf6_ona", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "behavior", "ssf10_sne", "ssf18_snm", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "extension_bcf", "ajcc6_m_codes", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng", "nodes_dbw" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/urethra.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/urethra.json
@@ -482,35 +482,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bdi",
@@ -605,32 +597,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -728,32 +712,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -855,11 +831,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_uaz",
@@ -898,8 +872,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -919,11 +892,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -942,11 +913,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qaw",
@@ -988,11 +957,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1003,8 +970,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1093,47 +1059,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1143,80 +1095,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ajcc7_stage_uaz", "ssf2_kna", "ajcc6_exclusions_ppd", "ssf25_snt", "ssf1_jpd", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "cs_input_version_original", "ssf22_snq", "mets_hpe", "lvi", "ssf14_sni", "ajcc_tdescriptor_cleanup", "ajcc6_stage_qaw", "ssf4_mna", "ajcc7_year_validation", "ssf21_snp", "ajcc7_inclusions_tpb", "ssf17_snl", "ajcc_descriptor_codes", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ssf3_lna", "ss_codes", "extension_bdi", "ssf6_ona", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "schema_selection_urethra", "behavior", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "cs_year_validation", "ssf24_sns", "nodes_dbu", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/urinary_other.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/urinary_other.json
@@ -482,35 +482,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bcy",
@@ -605,32 +597,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -728,32 +712,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -857,8 +833,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -878,11 +853,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -897,11 +870,9 @@
     "id" : "mapping_ajcc6",
     "name" : "AJCC 6",
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qna",
@@ -998,47 +969,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1048,80 +1005,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf2_kna", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "cs_input_version_original", "mets_hpa", "nodes_dcz", "ssf22_snq", "lvi", "ssf14_sni", "mets_eval_ina", "ajcc_tdescriptor_cleanup", "ssf4_mna", "extension_eval_cna", "ajcc6_stage_qna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "grade", "summary_stage_rpa", "nodes_eval_ena", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "ssf1_jna", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf11_snf", "ssf3_lna", "ss_codes", "ssf6_ona", "size_apa", "nodes_exam_gpa", "ajcc6_n_codes", "schema_selection_urinary_other", "behavior", "ssf10_sne", "ssf18_snm", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "extension_bcy", "ssf19_snn", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/vagina.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/vagina.json
@@ -482,35 +482,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bad",
@@ -605,32 +597,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -728,32 +712,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -855,11 +831,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_ubc",
@@ -898,8 +872,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -919,11 +892,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -942,11 +913,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qbr",
@@ -988,11 +957,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -1003,8 +970,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1093,47 +1059,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1143,80 +1095,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "ssf3_lpu", "ajcc6_exclusions_ppd", "ssf25_snt", "ssf15_snj", "ajcc7_t_codes", "ssf23_snr", "histology", "cs_input_version_original", "ssf22_snq", "lvi", "ssf14_sni", "ssf5_npm", "ajcc_tdescriptor_cleanup", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "ssf7_sdf", "ajcc7_inclusions_tph", "extension_bad", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "mets_haj", "nodes_dba", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf11_snf", "ss_codes", "size_apa", "nodes_exam_gpa", "ssf2_kpr", "ssf6_oaq", "schema_selection_vagina", "ajcc6_n_codes", "ajcc6_stage_qbr", "behavior", "ssf10_sne", "ssf18_snm", "mets_eval_ipa", "extension_eval_cpa", "ssf1_jbq", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf19_snn", "ajcc7_stage_codes", "ssf9_snd", "ssf13_snh", "primary_site", "ajcc6_year_validation", "ssf4_mps", "ajcc6_m_codes", "nodes_eval_epa", "ajcc7_stage_ubc", "cs_year_validation", "ssf24_sns", "ssf8_snc", "ssf12_sng" ],

--- a/src/main/resources/algorithms/cs/02.05.50/schemas/vulva.json
+++ b/src/main/resources/algorithms/cs/02.05.50/schemas/vulva.json
@@ -478,35 +478,27 @@
     "id" : "mapping_t",
     "name" : "T",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
       "key" : "ajcc6_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
       "key" : "ajcc7_tdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     } ],
     "tables" : [ {
       "id" : "extension_bbi",
@@ -601,32 +593,24 @@
     "id" : "mapping_n",
     "name" : "N",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
       "key" : "ajcc6_ndescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     }, {
       "key" : "ajcc7_ndescriptor",
       "value" : "ERROR"
@@ -724,32 +708,24 @@
     "id" : "mapping_m",
     "name" : "M",
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
       "key" : "ajcc6_mdescriptor",
       "value" : "ERROR"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
       "key" : "ajcc7_mdescriptor",
       "value" : "ERROR"
@@ -851,11 +827,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc7_stage_ubd",
@@ -894,8 +868,7 @@
       "key" : "stor_ajcc7_mdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
       "key" : "stor_ajcc7_stage",
       "value" : "888"
@@ -915,11 +888,9 @@
       "key" : "stor_ajcc7_n",
       "value" : "888"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
       "key" : "stor_ajcc7_m",
       "value" : "888"
@@ -938,11 +909,9 @@
       "inputs" : [ "hist" ]
     } ],
     "initial_context" : [ {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     } ],
     "tables" : [ {
       "id" : "ajcc6_stage_qpu",
@@ -984,11 +953,9 @@
       "key" : "stor_ajcc6_tdescriptor",
       "value" : "N"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
       "key" : "stor_ajcc6_ndescriptor",
       "value" : "N"
@@ -999,8 +966,7 @@
       "key" : "ajcc6_stage",
       "value" : "NA"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
       "key" : "stor_ajcc6_stage",
       "value" : "88"
@@ -1089,47 +1055,33 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc7_m",
-      "value" : ""
+      "key" : "stor_ajcc7_m"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc7_m",
-      "value" : ""
+      "key" : "ajcc7_m"
     }, {
-      "key" : "ajcc7_n",
-      "value" : ""
+      "key" : "ajcc7_n"
     }, {
-      "key" : "ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "ajcc7_mdescriptor"
     }, {
-      "key" : "ajcc7_stage",
-      "value" : ""
+      "key" : "ajcc7_stage"
     }, {
-      "key" : "stor_ajcc7_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_mdescriptor"
     }, {
-      "key" : "stor_ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_tdescriptor"
     }, {
-      "key" : "ajcc7_tdescriptor",
-      "value" : ""
+      "key" : "ajcc7_tdescriptor"
     }, {
-      "key" : "stor_ajcc7_t",
-      "value" : ""
+      "key" : "stor_ajcc7_t"
     }, {
-      "key" : "ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "ajcc7_ndescriptor"
     }, {
-      "key" : "ajcc7_t",
-      "value" : ""
+      "key" : "ajcc7_t"
     }, {
-      "key" : "stor_ajcc7_n",
-      "value" : ""
+      "key" : "stor_ajcc7_n"
     }, {
-      "key" : "stor_ajcc7_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc7_ndescriptor"
     } ]
   }, {
     "id" : "mapping_ajcc6_invalid_year",
@@ -1139,80 +1091,55 @@
       "inputs" : [ "year_dx", "cs_input_version_original" ]
     } ],
     "initial_context" : [ {
-      "key" : "stor_ajcc6_m",
-      "value" : ""
+      "key" : "stor_ajcc6_m"
     }, {
-      "key" : "stor_ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_ndescriptor"
     }, {
-      "key" : "n77",
-      "value" : ""
+      "key" : "n77"
     }, {
-      "key" : "stor_ajcc7_stage",
-      "value" : ""
+      "key" : "stor_ajcc7_stage"
     }, {
-      "key" : "ajcc6_m",
-      "value" : ""
+      "key" : "ajcc6_m"
     }, {
-      "key" : "t2000",
-      "value" : ""
+      "key" : "t2000"
     }, {
-      "key" : "ss77",
-      "value" : ""
+      "key" : "ss77"
     }, {
-      "key" : "stor_ss77",
-      "value" : ""
+      "key" : "stor_ss77"
     }, {
-      "key" : "ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "ajcc6_tdescriptor"
     }, {
-      "key" : "t77",
-      "value" : ""
+      "key" : "t77"
     }, {
-      "key" : "stor_ajcc6_stage",
-      "value" : ""
+      "key" : "stor_ajcc6_stage"
     }, {
-      "key" : "n2000",
-      "value" : ""
+      "key" : "n2000"
     }, {
-      "key" : "stor_ajcc6_t",
-      "value" : ""
+      "key" : "stor_ajcc6_t"
     }, {
-      "key" : "ajcc6_t",
-      "value" : ""
+      "key" : "ajcc6_t"
     }, {
-      "key" : "stor_ajcc6_n",
-      "value" : ""
+      "key" : "stor_ajcc6_n"
     }, {
-      "key" : "m2000",
-      "value" : ""
+      "key" : "m2000"
     }, {
-      "key" : "ss2000",
-      "value" : ""
+      "key" : "ss2000"
     }, {
-      "key" : "ajcc6_ndescriptor",
-      "value" : ""
+      "key" : "ajcc6_ndescriptor"
     }, {
-      "key" : "ajcc6_n",
-      "value" : ""
+      "key" : "ajcc6_n"
     }, {
-      "key" : "m77",
-      "value" : ""
+      "key" : "m77"
     }, {
-      "key" : "ajcc6_stage",
-      "value" : ""
+      "key" : "ajcc6_stage"
     }, {
-      "key" : "stor_ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ajcc6_tdescriptor",
-      "value" : ""
+      "key" : "stor_ajcc6_tdescriptor"
     }, {
-      "key" : "ajcc6_mdescriptor",
-      "value" : ""
+      "key" : "ajcc6_mdescriptor"
     }, {
-      "key" : "stor_ss2000",
-      "value" : ""
+      "key" : "stor_ss2000"
     } ]
   } ],
   "involved_tables" : [ "schema_selection_vulva", "ssf2_kna", "ajcc6_exclusions_ppd", "extension_size_ajcc7_xbl", "ssf25_snt", "ssf15_sfc", "ajcc7_t_codes", "ssf23_snr", "histology", "ajcc6_stage_qpu", "cs_input_version_original", "extension_bbi", "ssf22_snq", "lvi", "ssf14_sfb", "ajcc_tdescriptor_cleanup", "ssf4_mna", "ajcc7_year_validation", "ssf21_snp", "ssf17_snl", "ajcc_descriptor_codes", "grade", "summary_stage_rpa", "ajcc7_m_codes", "ajcc7_inclusions_tpq", "ssf20_sno", "ajcc_ndescriptor_cleanup", "ssf16_snk", "nodes_dbb", "ssf10_sex", "ssf1_jna", "ajcc6_t_codes", "nodes_pos_fpa", "ajcc_mdescriptor_cleanup", "ssf7_snb", "ssf3_lna", "ss_codes", "ssf11_srd", "ssf6_ona", "nodes_exam_gpa", "mets_hba", "ajcc6_n_codes", "extension_size_ajcc6_xqc", "behavior", "ssf18_snm", "mets_eval_ipa", "size_app", "extension_eval_cpa", "ajcc7_n_codes", "ajcc6_stage_codes", "ssf5_nna", "ssf19_snn", "ajcc7_stage_codes", "ssf13_sfa", "ssf9_snd", "lymph_nodes_ssf11_ajcc6_xqd", "primary_site", "ajcc6_year_validation", "ajcc6_m_codes", "nodes_eval_epa", "ajcc7_stage_ubd", "cs_year_validation", "ssf12_sez", "ssf24_sns", "ssf8_snc" ],

--- a/src/main/resources/algorithms/cs/02.05.50/tables/ajcc6_year_validation.json
+++ b/src/main/resources/algorithms/cs/02.05.50/tables/ajcc6_year_validation.json
@@ -4,7 +4,6 @@
   "version" : "02.05.50",
   "name" : "AJCC 6 Year Validation",
   "title" : "AJCC 6 Year Validation",
-  "notes" : "",
   "last_modified" : "2015-05-27T16:18:52.091Z",
   "definition" : [ {
     "key" : "year_dx",

--- a/src/main/resources/algorithms/cs/02.05.50/tables/ajcc7_year_validation.json
+++ b/src/main/resources/algorithms/cs/02.05.50/tables/ajcc7_year_validation.json
@@ -4,7 +4,6 @@
   "version" : "02.05.50",
   "name" : "AJCC7 Year Validation",
   "title" : "AJCC7 Year Validation",
-  "notes" : "",
   "last_modified" : "2015-05-27T16:19:00.662Z",
   "definition" : [ {
     "key" : "year_dx",

--- a/src/main/resources/algorithms/cs/02.05.50/tables/cs_year_validation.json
+++ b/src/main/resources/algorithms/cs/02.05.50/tables/cs_year_validation.json
@@ -4,7 +4,6 @@
   "version" : "02.05.50",
   "name" : "CS Year Validation",
   "title" : "CS Year Validation",
-  "notes" : "",
   "last_modified" : "2015-05-27T16:19:02.555Z",
   "definition" : [ {
     "key" : "year_dx",


### PR DESCRIPTION
- Myeloma Plasma Cell Disorders: the default values for CS Lymph  Nodes, SSF2 - Durie-Salmon Staging System,  and SSF3 - Multiple Myeloma Terminology were removed. Previously these values had been footnote indicators rather than valid values.

The reason there are additional changes is the download process is removing redundant blanks from the files.